### PR TITLE
Removed extra comma in 0-build_srr.R

### DIFF
--- a/R/0-build_srr.R
+++ b/R/0-build_srr.R
@@ -51,7 +51,7 @@ build_srr <- function(srr_fun = 0,
        srr_est_mode = srr_est_mode,
        srr_prior_mean = srr_prior_mean,
        srr_prior_sd = srr_prior_sd,
-       Bmsy_lim = Bmsy_lim,
+       Bmsy_lim = Bmsy_lim
   )
 }
 


### PR DESCRIPTION
Removed an extra comma in the `build_srr` function that caused an error when running `fit_mod()` with random recruitment or selectivity.

NB: still getting `Error in nlminb(obj$par, obj$fn, obj$gr, control = control) : NA/NaN gradient evaluation` with `random_sel = TRUE`, but `random_rec = TRUE` is working.