### PR TITLE
Fix bug in last_par returning the wrong vector in fit_mod

### DIFF
--- a/R/6-fit_mod.R
+++ b/R/6-fit_mod.R
@@ -641,13 +641,8 @@ fit_mod <-
     if (estimateMode > 1) { # debugging / projection-only: use initial parameters
       last_par <- start_par
     } else {
-      if (length(random_vars) == 0) {
-        last_par <- try(obj$env$parList(obj$env$last.par.best))
-      } else {
-        last_par <- try(obj$env$parList())
-      }
+      last_par <- try(obj$env$parList(par=obj$env$last.par.best))
     }
-
 
     #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
     # 10: Run projection ----
@@ -753,11 +748,7 @@ fit_mod <-
         if (estimateMode > 2) { # debugging: use initial parameters
           last_par <- start_par
         } else {
-          if (length(random_vars) == 0) {
-            last_par <- try(obj$env$parList(obj$env$last.par.best))
-          } else {
-            last_par <- try(obj$env$parList())
-          }
+            last_par <- try(obj$env$parList(par=obj$env$last.par.best))
         }
 
 

--- a/R/6-fit_mod.R
+++ b/R/6-fit_mod.R
@@ -641,7 +641,7 @@ fit_mod <-
     if (estimateMode > 1) { # debugging / projection-only: use initial parameters
       last_par <- start_par
     } else {
-      last_par <- try(obj$env$parList(par=obj$env$last.par.best))
+      last_par <- obj$env$parList(par=obj$env$last.par.best)
     }
 
     #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
@@ -748,7 +748,7 @@ fit_mod <-
         if (estimateMode > 2) { # debugging: use initial parameters
           last_par <- start_par
         } else {
-            last_par <- try(obj$env$parList(par=obj$env$last.par.best))
+          last_par <- obj$env$parList(par=obj$env$last.par.best)
         }
 
 


### PR DESCRIPTION
There was a small bug in the `last_par` calculation in `fit_mod` which would pass the wrong vector in via the argument `x`. It's much simpler and safer to pass the joint in as `obj$env$parList(par=obj$env$last.par.best` and let TMB subset down to the fixed effects.

This passes tests locally. One lingering question is what the `try` statement is doing here. Is this robust if it fails?