### PR TITLE
[codex] Update build ignores for local artifacts

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,8 +13,12 @@
 ^.*/\.DS_Store$
 ^~\$.*$
 ^.*/~\$.*$
+^\.vscode$
 ^R/dev$
 ^src/TMB/Dev$
+^src/TMB/Depricated$
+^vignettes/.*[.]pptx$
+^HCR[.]qmd$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^\.github$


### PR DESCRIPTION
## Summary

Adds R build ignore patterns for local editor, HCR, PowerPoint, and deprecated TMB development artifacts so they are not included when building the package from a working checkout.

The dev branch already contains the dependency/import fixes and reorganized test files without the malformed `test_that()` calls, so this PR carries the remaining dev-relevant cleanup.

## Validation

- Parsed package/test R files outside `R/dev` with Framework R 4.6: `parsed=97/97`
- Built package with Framework R 4.6: `R CMD build --no-build-vignettes .`
