### PR TITLE
Add option to specify bias ajustment to lognormal data and process likelihoods

### DIFF
--- a/R/0-fit_control.R
+++ b/R/0-fit_control.R
@@ -48,6 +48,12 @@
 #'   internal re-fits inherit it. `NULL` (the default) inherits
 #'   `data_list$comp_offset` if set, otherwise `1e-5`; a number overrides it.
 #'   Does not apply to diet (stomach-content) compositions.
+#' @param bias_adjust_obs logical with default TRUE. Whether to
+#'   apply a bias adjustment (mean-sd^2/2) to lognormal data
+#'   likelihoods
+#' @param bias_adjust_proc logical with default TRUE. Whether to
+#'   apply a bias adjustment (mean-sd^2/2) to lognormal process
+#'   likelihoods
 #' @param use_gradient logical. Use the analytic gradient during
 #'   phasing. Default `TRUE`.
 #' @param rel_tol Numeric tolerance used to flag discontinuous
@@ -89,6 +95,8 @@ fit_control <- function(
   projection_uncertainty = FALSE,
   osa                 = FALSE,
   comp_offset         = NULL,
+  bias_adjust_obs     = TRUE,
+  bias_adjust_proc    = TRUE,
   use_gradient        = TRUE,
   rel_tol             = 1,
   loopnum             = 5,
@@ -106,6 +114,8 @@ fit_control <- function(
     projection_uncertainty = projection_uncertainty,
     osa                 = osa,
     comp_offset         = comp_offset,
+    bias_adjust_obs     = bias_adjust_obs,
+    bias_adjust_proc    = bias_adjust_proc,
     use_gradient        = use_gradient,
     rel_tol             = rel_tol,
     loopnum             = loopnum,

--- a/R/6-fit_mod.R
+++ b/R/6-fit_mod.R
@@ -442,6 +442,10 @@ fit_mod <-
     if (!is.null(fit_control$comp_offset)) data_list$comp_offset <- fit_control$comp_offset
     if (is.null(data_list$comp_offset))    data_list$comp_offset <- 1e-5
 
+    data_list$bias_adjust_obs <- data_list$bias_adjust_proc <- 1
+    if(!is.null(fit_control$bias_adjust_obs)) data_list$bias_adjust_obs <- fit_control$bias_adjust_obs
+    if(!is.null(fit_control$bias_adjust_proc)) data_list$bias_adjust_proc <- fit_control$bias_adjust_proc
+
     # Reorganize data for .cpp file
     data_list_reorganized <- Rceattle::rearrange_data(data_list, build_osa = osa)
     data_list_reorganized <- c(list(model = TMBfilename), data_list_reorganized)

--- a/man/fit_control.Rd
+++ b/man/fit_control.Rd
@@ -12,6 +12,8 @@ fit_control(
   projection_uncertainty = FALSE,
   osa = FALSE,
   comp_offset = NULL,
+  bias_adjust_obs = TRUE,
+  bias_adjust_proc = TRUE,
   use_gradient = TRUE,
   rel_tol = 1,
   loopnum = 5,
@@ -57,6 +59,14 @@ likelihood and the OSA observation vector use the same offset, and so
 internal re-fits inherit it. \code{NULL} (the default) inherits
 \code{data_list$comp_offset} if set, otherwise \code{1e-5}; a number overrides it.
 Does not apply to diet (stomach-content) compositions.}
+
+\item{bias_adjust_obs}{logical with default TRUE. Whether to
+apply a bias adjustment (mean-sd^2/2) to lognormal data
+likelihoods}
+
+\item{bias_adjust_proc}{logical with default TRUE. Whether to
+apply a bias adjustment (mean-sd^2/2) to lognormal process
+likelihoods}
 
 \item{use_gradient}{logical. Use the analytic gradient during
 phasing. Default \code{TRUE}.}

--- a/src/TMB/ceattle_v01_11.cpp
+++ b/src/TMB/ceattle_v01_11.cpp
@@ -315,6 +315,8 @@ Type objective_function<Type>::operator() () {
   // -- 2.4.3. Others
   DATA_MATRIX( sex_ratio );               // Proportion-at-age of females of population
   DATA_MATRIX( maturity );                // Proportion of mature females at age; [nspp, nages]
+  DATA_SCALAR(bias_adjust_obs);           // Whether to apply bias adjustment (-sigma^2/2) in index likelihoods
+  DATA_SCALAR(bias_adjust_proc);           // Whether to apply bias adjustment (-sigma^2/2) in process likelihoods
 
 
   /** ------------------------------------------------------------------------ //
@@ -2399,7 +2401,7 @@ Type objective_function<Type>::operator() () {
         // fitting) and obsvec(pos) == log(index_obs) this equals the original
         // lognormal likelihood exactly.
         int pos = index_obsvec_idx(index_ind);
-        jnll_comp(0, index) -= keep(pos) * dnorm(obsvec(pos), log(index_hat(index_ind)) - square(index_std_dev)/2.0, index_std_dev, true);
+        jnll_comp(0, index) -= keep(pos) * dnorm(obsvec(pos), log(index_hat(index_ind)) - bias_adjust_obs*square(index_std_dev)/2.0, index_std_dev, true);
       }
     }
   }
@@ -2435,7 +2437,7 @@ Type objective_function<Type>::operator() () {
         // residuals (see the index slot above). With keep == 1 and
         // obsvec(pos) == log(catch_obs) this equals the original likelihood.
         int pos = catch_obsvec_idx(fsh_ind);
-        jnll_comp(1, flt) -= keep(pos) * dnorm(obsvec(pos), log(catch_hat(fsh_ind)) - square(fsh_std_dev)/2.0, fsh_std_dev, true) ;
+        jnll_comp(1, flt) -= keep(pos) * dnorm(obsvec(pos), log(catch_hat(fsh_ind)) - bias_adjust_obs*square(fsh_std_dev)/2.0, fsh_std_dev, true) ;
         // Martin's
         // jnll_comp(1, flt)+= 0.5*square((log(catch_obs(fsh_ind, 0))-log(catch_hat(fsh_ind)))/fsh_std_dev);
       }
@@ -2845,7 +2847,7 @@ Type objective_function<Type>::operator() () {
     // Slot 9 -- stock-recruit prior for Beverton
     // -- Lognormal
     if((srr_est_mode == 2) & ((srr_pred_fun == 2) | (srr_pred_fun == 3))){
-      jnll_comp(8, sp) -= dnorm(log(steepness(sp, 0)), log(srr_prior(sp)) + square(srr_prior_sd(sp))/2.0, srr_prior_sd(sp), true);
+      jnll_comp(8, sp) -= dnorm(log(steepness(sp, 0)), log(srr_prior(sp)) + bias_adjust_proc*square(srr_prior_sd(sp))/2.0, srr_prior_sd(sp), true);
     }
 
     // -- Beta
@@ -2873,14 +2875,14 @@ Type objective_function<Type>::operator() () {
     // Lognormal bias correction: dev ~ N(-sigma^2/2, sigma) so E[N_init] = deterministic equilibrium.
     if(initMode > 1){
       for(age = 1; age < nages(sp); age++) {
-        jnll_comp(9, sp) -= dnorm( init_dev(sp, age - 1), -square(R_sd(sp))/2.0, R_sd(sp), true);
+        jnll_comp(9, sp) -= dnorm( init_dev(sp, age - 1), -bias_adjust_proc*square(R_sd(sp))/2.0, R_sd(sp), true);
       }
     }
 
     // Slot 10 -- Tau -- Annual recruitment deviation
     // Lognormal bias correction: dev ~ N(-sigma^2/2, sigma) so E[R] = R0 (mean-unbiased).
     for(yr = 0; yr < nyrs_hind; yr++) {
-      jnll_comp(10, sp) -= dnorm( rec_dev(sp, yr),  -square(R_sd(sp))/2.0, R_sd(sp), true);    // Recruitment deviation using random effects.
+      jnll_comp(10, sp) -= dnorm( rec_dev(sp, yr),  -bias_adjust_proc*square(R_sd(sp))/2.0, R_sd(sp), true);    // Recruitment deviation using random effects.
     }
 
     // Slot 11 -- Additional penalty for SRR curve (sensu AMAK/Ianelli)

--- a/tests/testthat/tests-Likelihoods/test-bias-adjust.R
+++ b/tests/testthat/tests-Likelihoods/test-bias-adjust.R
@@ -6,7 +6,7 @@ testthat::test_that("Bias adjustment of data and process likelihoods works", {
   nages = 5
   R0 = 3.5
   nyrs = 8
-  source(file.path("tests", "testthat", "helpers.R"))
+ # source(file.path("tests", "testthat", "helpers.R"))
   dat <- make_test_data(nyrs = nyrs, nages = nages, seed = 42)
 
   out <- list()

--- a/tests/testthat/tests-Likelihoods/test-bias-adjust.R
+++ b/tests/testthat/tests-Likelihoods/test-bias-adjust.R
@@ -1,0 +1,33 @@
+
+testthat::test_that("Bias adjustment of data and process likelihoods works", {
+  testthat::skip_if_not_installed("TMB")
+  testthat::skip_if_not_installed("Rceattle")
+
+  nages = 5
+  R0 = 3.5
+  nyrs = 8
+  source(file.path("tests", "testthat", "helpers.R"))
+  dat <- make_test_data(nyrs = nyrs, nages = nages, seed = 42)
+
+  out <- list()
+  for(obs in c(TRUE,FALSE)){
+    for(proc in c(TRUE,FALSE)){
+      m <- Rceattle::fit_mod(data_list = dat,
+                             fit_control = fit_control(
+                               bias_adjust_obs = obs,
+                               bias_adjust_proc = proc,
+                               phase = TRUE, getsd = FALSE,
+
+
+                               verbose = 0))
+      R0 <- m$estimated_params$rec_pars[1]
+      out <- rbind(out, data.frame(obs=obs, proc=proc, logssb_terminal=m$quantities$log_ssb[1,18], R0=R0))
+    }
+  }
+  out
+  testthat::expect_equal(out[3,3], out[4,3], tolerance = 1e-5)
+  testthat::expect_equal(out[3,4], out[4,4]+0.5, tolerance = 1e-5)
+  testthat::expect_equal(out[1,3], 4.227271, tolerance=1e-5)
+  testthat::expect_equal(out[3,3], 4.223244, tolerance=1e-5)
+
+})

--- a/tests/testthat/tests-Likelihoods/test-bias-adjust.R
+++ b/tests/testthat/tests-Likelihoods/test-bias-adjust.R
@@ -10,24 +10,29 @@ testthat::test_that("Bias adjustment of data and process likelihoods works", {
   dat <- make_test_data(nyrs = nyrs, nages = nages, seed = 42)
 
   out <- list()
-  for(obs in c(TRUE,FALSE)){
-    for(proc in c(TRUE,FALSE)){
-      m <- Rceattle::fit_mod(data_list = dat,
-                             fit_control = fit_control(
-                               bias_adjust_obs = obs,
-                               bias_adjust_proc = proc,
-                               phase = TRUE, getsd = FALSE,
-
-
-                               verbose = 0))
-      R0 <- m$estimated_params$rec_pars[1]
-      out <- rbind(out, data.frame(obs=obs, proc=proc, logssb_terminal=m$quantities$log_ssb[1,18], R0=R0))
+  for(osa in c(FALSE,TRUE)){
+    for(obs in c(TRUE,FALSE)){
+      for(proc in c(TRUE,FALSE)){
+        m <- Rceattle::fit_mod(data_list = dat,
+                               fit_control = fit_control(
+                                 bias_adjust_obs = obs,
+                                 bias_adjust_proc = proc,
+                                 osa=osa,
+                                 phase = TRUE, getsd = FALSE,
+                                 verbose = 0))
+        R0 <- m$estimated_params$rec_pars[1]
+        out <- rbind(out, data.frame(obs=obs, proc=proc, osa=osa, logssb_terminal=m$quantities$log_ssb[1,18], R0=R0))
+      }
     }
   }
   out
-  testthat::expect_equal(out[3,3], out[4,3], tolerance = 1e-5)
-  testthat::expect_equal(out[3,4], out[4,4]+0.5, tolerance = 1e-5)
-  testthat::expect_equal(out[1,3], 4.227271, tolerance=1e-5)
-  testthat::expect_equal(out[3,3], 4.223244, tolerance=1e-5)
-
+  # first check that with OSA off it performs as expected,
+  # sigmaR=1 so adjustment is -0.5, R0 is offset that much to
+  # counteract when proc=TRUE
+  testthat::expect_equal(out[3,4], out[4,4], tolerance = 1e-5)
+  testthat::expect_equal(out[3,5], out[4,5]+0.5, tolerance = 1e-5)
+  testthat::expect_equal(out[1,4], 4.227271, tolerance=1e-5)
+  testthat::expect_equal(out[3,4], 4.223244, tolerance=1e-5)
+  # now test that OSA does not change anything
+  testthat::expect_equal(sum(out[1:4,4:5]),sum(out[5:8,4:5]))
 })


### PR DESCRIPTION
The user can now pass `bias_adjust_obs` and `bias_adjust_proc` to specify whether log-normal bias adjustment should be applied to data and process likelihoods, respectively. The default is 1 so it is backward compatible. The user specifies this via `fit_control()`.

The bias adjustment subtracts off SD^2/2 from the mean in the `dnorm` statements so that the quantity is mean unbiased instead of median.  This is needed because some AFSC models use it and others do not so it will be useful for bridging exercises.

A new test file 'tests/test-Likelihoods/test-bias-adjust.R' was also added and passes. This checks basic functionality including no impact of `osa=TRUE` in `fit_control`.

Code wise I decided to have a boolean flag then multiply the subtracted quantity (0 turns it off, 1 turns it on). WHAM does this with an 'if' statement which may have some C++ advantages. Happy to switch if you prefer that. 