### PR TITLE
Move spawning biomass per recruit into spr.hpp, and stop it being read under predation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,8 @@ rcmdcheck::rcmdcheck()                 # what CI runs (slow; usually backgrounde
   — don't renumber or rename wholesale.**
 - **`src/TMB/`** — `ceattle.cpp` is the main model (numbered section index); process logic lives
   in headers (`recruitment.hpp`, `selectivity.hpp`, `predation.hpp`, `growth.hpp`, `linkage.hpp`,
-  `comp_osa.hpp`, `comp_sim.hpp`, `helper_functions.hpp`, `bioenergetics.hpp`, `diet_data.hpp`).
+  `spr.hpp`, `comp_osa.hpp`, `comp_sim.hpp`, `helper_functions.hpp`, `bioenergetics.hpp`,
+  `diet_data.hpp`).
   `jnll_comp` rows are addressed by the **`JnllRow` enum** — refer to a row by its constant,
   never a bare integer. Display names live separately in `R/6-rename_output.R` and are kept in
   sync by hand; adding or reordering a component means updating both.

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,23 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
 
 ## Breaking changes
 
+* **A Beverton-Holt or Ricker stock-recruit curve can no longer be combined
+  with `msmMode > 0`.** `data_check()` now refuses it. Those curves anchor
+  steepness, `R0` and `R_init` on spawning biomass per recruit, and SPR is not
+  defined under predation: total mortality carries `M2`, which scales with
+  predator abundance, so per-recruit spawning output is not a property of the
+  prey stock alone. The template has always declined to compute it under
+  multispecies mode -- but the code that consumes it was never gated to match,
+  so `SPR0 = 0` reached it. With `srr_fun >= 2` that is a division by zero:
+  `R0` and `R_init` came back `-Inf` and the objective `NaN`. With the Ianelli
+  configuration (`srr_fun` mean, `srr_pred_fun` Beverton-Holt or Ricker) it was
+  worse, because **the fit ran to completion** and reported a finite objective
+  with `steepness` silently 0 and `R_hat` `-Inf`.
+
+  Nothing that produced a usable fit is refused. Use
+  `build_srr(srr_fun = "mean", srr_pred_fun = "mean")` under predation, or fit
+  the stock-recruit curve in single-species mode.
+
 * **Three `fleet_control` columns are now validated: `Selectivity_dimension`,
   `Sel_shape_dir` and `Sel_shape_mode`.** A typo in any of them previously
   resolved to `NA` rather than erroring -- `Selectivity_dimension` became a

--- a/NEWS.md
+++ b/NEWS.md
@@ -200,6 +200,14 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
   (`SingleSpecies (0) / MSVPA (1) / TypeIIIMSVPA (2)`), since a saved config
   writes the switch as the number.
 
+## Minor improvements
+
+* **`quantities$NbyageSPR` now carries dimension names.** Its first dimension is
+  a reference point rather than a species -- `c("F0", "Flimit", "Ftarget",
+  "Finit")` -- so reading it no longer means knowing that slot 3 is `Finit`.
+  Species and age bins are labelled to match the other numbers-at-age arrays.
+  Positional indexing is unchanged.
+
 # Rceattle 5.11.1
 
 ## Documentation

--- a/R/1-data_check.R
+++ b/R/1-data_check.R
@@ -1464,6 +1464,42 @@ data_check <- function(data_list) {
     errors <- c(errors, "msmMode > 0 requires other_food > 0 for all species; zero values cause divide-by-zero in suitability")
   }
 
+  # A Beverton-Holt or Ricker curve is anchored on spawning biomass per recruit:
+  # steepness, R0 and R_init are all derived from SPR0 or SPRFinit. Under
+  # predation those are not defined -- total mortality carries M2, which scales
+  # with predator abundance, so per-recruit spawning output is not a property of
+  # the prey stock alone -- and section 6.2 of the template does not compute
+  # them. The consumers in section 6.3 were never gated to match, so SPR0 = 0
+  # reached them: with srr_fun >= 2 that is 1/0, giving R0 = -Inf and a NaN
+  # objective; with the Ianelli configuration (srr_fun < 2, srr_pred_fun >= 2)
+  # it is worse, because the fit RUNS -- steepness comes out 0, R_hat -Inf, and
+  # the objective is finite. Refuse the combination rather than report either.
+  # Resolve through .SRR_FUNS rather than comparing the raw value: build_srr()
+  # coerces to an integer code, but a hand-built data_list can still carry the
+  # string, and in R `"mean" >= 2` is TRUE -- a character comparison that would
+  # refuse a perfectly good mean-recruitment multispecies model. An unrecognised
+  # value is validate_switches()' business to report, not this check's.
+  .srr_needs_spr <- function(x) {
+    if (is.null(x) || length(x) != 1L || all(is.na(x))) return(FALSE)
+    code <- if (is.numeric(x)) as.integer(x) else unname(.SRR_FUNS[as.character(x)])
+    isTRUE(!is.na(code) && code >= 2L)
+  }
+  if(!is.null(data_list$msmMode) && any(data_list$msmMode > 0)){
+    bad_srr <- c(if(.srr_needs_spr(data_list$srr_fun)) "srr_fun",
+                 if(.srr_needs_spr(data_list$srr_pred_fun)) "srr_pred_fun")
+    if(length(bad_srr)){
+      errors <- c(errors, paste0(
+        "msmMode > 0 cannot be combined with a Beverton-Holt or Ricker ",
+        paste(bad_srr, collapse = " / "), ". Those curves are anchored on ",
+        "spawning biomass per recruit, which is undefined under predation: ",
+        "total mortality includes M2, so per-recruit spawning output depends on ",
+        "predator abundance rather than on the prey stock alone. SPR0 is left at ",
+        "0 and the derived steepness, R0 and R_init are meaningless. Use ",
+        "build_srr(srr_fun = 'mean', srr_pred_fun = 'mean'), or fit the ",
+        "stock-recruit curve in single-species mode."))
+    }
+  }
+
   # Bioenergetics scalars: required (length nspp) when msmMode > 0. switch_check
   # fills these with safe sentinels in single-species mode, so the only way
   # they're missing or wrong-length here is in multispecies mode. The 12 scalars

--- a/R/6-rename_output.R
+++ b/R/6-rename_output.R
@@ -100,6 +100,13 @@ rename_output <- function(data_list = NULL, quantities = NULL){
   dimnames(quantities$N_at_age) <- list(data_list$spnames, sex_labels, paste0("Age", 1:max_age), yrs_proj)
   dimnames(quantities$NByage0) <- list(data_list$spnames, sex_labels, paste0("Age", 1:max_age), yrs_proj)
   dimnames(quantities$NByageF) <- list(data_list$spnames, sex_labels, paste0("Age", 1:max_age), yrs_proj)
+  # 3D, and the only quantity whose first dimension is a reference point rather
+  # than a species: numbers at age per recruit, in the order section 6.2 writes
+  # them. Unlabelled it reads as NbyageSPR[3, 1, ], which requires knowing that
+  # 3 is Finit. Ages follow the convention above -- the label is the age bin
+  # index, so it is the age itself only when minage is 1.
+  dimnames(quantities$NbyageSPR) <- list(c("F0", "Flimit", "Ftarget", "Finit"),
+                                         data_list$spnames, paste0("Age", 1:max_age))
   # `growth_parameters` and `growth_linkage_offset` carry only the
   # mean-growth params (log_K, log_L1, log_Linf, log_m); the SD
   # endpoints in `GROWTH_LINKAGE_PARAMS` live on `growth_log_sd` and

--- a/inst/dev/BACKLOG-PLAN.md
+++ b/inst/dev/BACKLOG-PLAN.md
@@ -6,7 +6,7 @@ that make several of these safe to touch.
 
 ## The shape of the problem
 
-81 `TODO`/`FIXME` markers, triaged into three tiers. **The tiers are not a priority order.** A
+79 `TODO`/`FIXME` markers, triaged into three tiers. **The tiers are not a priority order.** A
 Tier 0 "known defect" that no live assessment can reach is less urgent than a Tier 1 limitation
 every MSE run hits. Sequence by *who is exposed*, not by tier label.
 

--- a/inst/dev/CLEANUP_BACKLOG.md
+++ b/inst/dev/CLEANUP_BACKLOG.md
@@ -1,6 +1,6 @@
 # Cleanup backlog
 
-The 81 `TODO` / `FIXME` markers in the source, triaged. **Add to this file; don't fix these
+The 79 `TODO` / `FIXME` markers in the source, triaged. **Add to this file; don't fix these
 unasked.** Fix the one in the file you were already asked to touch, in the same commit.
 
 **Cite the marker text, not a line number.** These references have gone stale three times --

--- a/src/TMB/ceattle.cpp
+++ b/src/TMB/ceattle.cpp
@@ -24,6 +24,7 @@
 #include "growth.hpp"
 #include "selectivity.hpp"
 #include "recruitment.hpp"
+#include "spr.hpp"
 #include "bioenergetics.hpp"
 #include "predation.hpp"
 #include "diet_data.hpp"
@@ -581,7 +582,10 @@ Type objective_function<Type>::operator() () {
   matrix<Type>  DynamicSB0(nspp, nyrs); DynamicSB0.setZero();                       // Estimated dynamic spawning biomass at F = 0 (accounts for S_at_age-R curve)
   matrix<Type>  DynamicB0(nspp, nyrs); DynamicB0.setZero();                         // Estimated dynamic  biomass at F = 0 (accounts for S_at_age-R curve)
   matrix<Type>  DynamicSBF(nspp, nyrs); DynamicSBF.setZero();                       // Estimated dynamic spawning biomass at F = Ftarget (accounts for S_at_age-R curve)
-  array<Type>   NbyageSPR(4, nspp, max_age);                                        // Estimated numbers at age for spawning biomass per recruit reference points
+  // Zeroed explicitly, like every other array here: the recursion writes only
+  // ages below a species' own nages, and nothing at all under predation, so the
+  // rest is read from the REPORT as whatever it was initialised to.
+  array<Type>   NbyageSPR(4, nspp, max_age); NbyageSPR.setZero();                   // Numbers at age per recruit for the SPR reference points; slots 0-3 are F = 0, Flimit, Ftarget, Finit
   vector<Type>  SPRlimit(nspp); SPRlimit.setZero();                                 // Estimated Plimit SPR
   vector<Type>  SPRtarget(nspp); SPRtarget.setZero();                               // Estimated Ptarget SPR
   vector<Type>  SPR0(nspp); SPR0.setZero();                                         // Estimated spawning biomass per recruit at F = 0
@@ -1521,36 +1525,54 @@ Type objective_function<Type>::operator() () {
     SPRFinit.setZero();
     SPRlimit.setZero();
     SPRtarget.setZero();
+    // Not defined under predation: M carries M2, which scales with predator
+    // abundance, so spawning output per recruit would not be a property of the
+    // prey stock alone. data_check() refuses the switch combinations that read
+    // these downstream.
     if(msmMode == 0){
       for(sp = 0; sp < nspp; sp++) {
 
-        //FIXME: set to 1
-        NbyageSPR(0, sp, 0) = 1.0; // F = 0
-        NbyageSPR(1, sp, 0) = 1.0; // F = Flimit
-        NbyageSPR(2, sp, 0) = 1.0; // F = Ftarget
-        NbyageSPR(3, sp, 0) = 1.0; // F = Finit
+        int na = nages(sp);
+        int term_yr = nyrs_hind - 1;      // rates for a reference point are the terminal hindcast year's
+        wt_idx_ssb = 2 * sp + 1;
 
-        for(age = 1; age < nages(sp)-1; age++) {
-          NbyageSPR(0, sp, age) =  NbyageSPR(0, sp, age-1) * exp(-M_at_age(sp, 0, age-1, nyrs_hind - 1));
-          NbyageSPR(1, sp, age) =  NbyageSPR(1, sp, age-1) * exp(-(M_at_age(sp, 0, age-1, nyrs_hind - 1) + Flimit_at_age(sp, 0, age-1, nyrs_hind - 1))); //FIXME: time-vary sel in the forecast
-          NbyageSPR(2, sp, age) =  NbyageSPR(2, sp, age-1) * exp(-(M_at_age(sp, 0, age-1, nyrs_hind - 1) + Ftarget_at_age(sp, 0, age-1, nyrs_hind - 1)));
-          NbyageSPR(3, sp, age) =  NbyageSPR(3, sp, age-1) * exp(-(M_at_age(sp, 0, age-1, 0) + Finit(sp)));
+        // The four schedules. Flimit and Ftarget are selectivity-scaled and
+        // read the terminal hindcast year; Finit is the flat F that generated
+        // the initial age structure, so it is constant across ages and reads
+        // year 0, weight included.
+        // FIXME: time-vary sel in the forecast
+        vector<Type> Z_unfished(na), Z_limit(na), Z_target(na), Z_init(na);
+        vector<Type> wt_term(na), wt_first(na), mature_at_age(na), female_at_age(na);
+
+        for(age = 0; age < na; age++){
+          Z_unfished(age) = M_at_age(sp, 0, age, term_yr);
+          Z_limit(age)    = M_at_age(sp, 0, age, term_yr) + Flimit_at_age(sp, 0, age, term_yr);
+          Z_target(age)   = M_at_age(sp, 0, age, term_yr) + Ftarget_at_age(sp, 0, age, term_yr);
+          Z_init(age)     = M_at_age(sp, 0, age, 0) + Finit(sp);
+
+          wt_term(age)      = weight_hat(wt_idx_ssb, 0, age, term_yr);
+          wt_first(age)     = weight_hat(wt_idx_ssb, 0, age, 0);
+          //FIXME: use estimated sex_ratio for two-sex models?
+          mature_at_age(age) = maturity(sp, age);
+          female_at_age(age) = sex_ratio(sp, age);
         }
 
-        // Plus group
-        NbyageSPR(0, sp, nages(sp) - 1) = NbyageSPR(0, sp, nages(sp) - 2) * exp(-M_at_age(sp, 0, nages(sp) - 2, nyrs_hind - 1)) / (1 - exp(-M_at_age(sp, 0, nages(sp) - 1, nyrs_hind - 1)));
-        NbyageSPR(1, sp, nages(sp) - 1) = NbyageSPR(1, sp, nages(sp) - 2) * exp(-(M_at_age(sp, 0,  nages(sp) - 2, nyrs_hind - 1) + Flimit_at_age(sp, 0,  nages(sp) - 2, nyrs_hind - 1))) / (1 - exp(-(M_at_age(sp, 0,  nages(sp) - 1, nyrs_hind - 1) + Flimit_at_age(sp, 0,  nages(sp) - 1, nyrs_hind - 1))));
-        NbyageSPR(2, sp, nages(sp) - 1) = NbyageSPR(2, sp, nages(sp) - 2) * exp(-(M_at_age(sp, 0,  nages(sp) - 2, nyrs_hind - 1) + Ftarget_at_age(sp, 0,  nages(sp) - 2, nyrs_hind - 1))) / (1 - exp(-(M_at_age(sp, 0,  nages(sp) - 1, nyrs_hind - 1) + Ftarget_at_age(sp, 0,  nages(sp) - 1, nyrs_hind - 1))));
-        NbyageSPR(3, sp, nages(sp) - 1) = NbyageSPR(3, sp, nages(sp) - 2) * exp(-(M_at_age(sp, 0,  nages(sp) - 2, 0) + Finit(sp))) / (1 - exp(-(M_at_age(sp, 0,  nages(sp) - 1, 0) + Finit(sp))));
+        vector<Type> n_unfished = per_recruit_survivors(Z_unfished);
+        vector<Type> n_limit    = per_recruit_survivors(Z_limit);
+        vector<Type> n_target   = per_recruit_survivors(Z_target);
+        vector<Type> n_init     = per_recruit_survivors(Z_init);
 
-        // Calculate SPRss_
-        //FIXME: use estimated sex_ratio for two-sex models?
-        for(age = 0; age < nages(sp); age++) {
-          wt_idx_ssb = 2 * sp + 1;
-          SPR0(sp) +=  NbyageSPR(0, sp, age) *  weight_hat( wt_idx_ssb, 0, age, (nyrs_hind - 1) ) * maturity( sp, age ) * sex_ratio(sp, age) * exp(-M_at_age(sp, 0,  age, nyrs_hind - 1) * spawn_month(sp)/12.0);
-          SPRlimit(sp) +=  NbyageSPR(1, sp, age) *  weight_hat( wt_idx_ssb, 0, age, (nyrs_hind - 1) ) * maturity( sp, age ) * sex_ratio(sp, age) * exp(-(M_at_age(sp, 0,  age, nyrs_hind - 1) + Flimit_at_age(sp, 0,  age, nyrs_hind - 1)) * spawn_month(sp)/12.0);
-          SPRtarget(sp) +=  NbyageSPR(2, sp, age) *  weight_hat( wt_idx_ssb, 0, age, (nyrs_hind - 1) ) * maturity( sp, age ) * sex_ratio(sp, age) * exp(-(M_at_age(sp, 0,  age, nyrs_hind - 1) + Ftarget_at_age(sp, 0,  age, nyrs_hind - 1)) * spawn_month(sp)/12.0);
-          SPRFinit(sp) +=  NbyageSPR(3, sp, age) *  weight_hat( wt_idx_ssb, 0, age, 0) * maturity( sp, age ) * sex_ratio(sp, age) * exp(-(M_at_age(sp, 0,  age, 0) + Finit(sp)) * spawn_month(sp)/12.0);
+        SPR0(sp)      = spawning_biomass_per_recruit(n_unfished, Z_unfished, wt_term,  mature_at_age, female_at_age, spawn_month(sp));
+        SPRlimit(sp)  = spawning_biomass_per_recruit(n_limit,    Z_limit,    wt_term,  mature_at_age, female_at_age, spawn_month(sp));
+        SPRtarget(sp) = spawning_biomass_per_recruit(n_target,   Z_target,   wt_term,  mature_at_age, female_at_age, spawn_month(sp));
+        SPRFinit(sp)  = spawning_biomass_per_recruit(n_init,     Z_init,     wt_first, mature_at_age, female_at_age, spawn_month(sp));
+
+        // Reported for inspection; slot order matches the four calls above.
+        for(age = 0; age < na; age++){
+          NbyageSPR(0, sp, age) = n_unfished(age);
+          NbyageSPR(1, sp, age) = n_limit(age);
+          NbyageSPR(2, sp, age) = n_target(age);
+          NbyageSPR(3, sp, age) = n_init(age);
         }
       }
     }

--- a/src/TMB/spr.hpp
+++ b/src/TMB/spr.hpp
@@ -1,0 +1,81 @@
+#ifndef SPR_HPP
+#define SPR_HPP
+
+/**
+ * @file spr.hpp
+ * @brief Spawning biomass per recruit, for the Amendment-56 SPR proxies.
+ *
+ * F40% and F35% are the F that leave a target fraction of unfished spawning
+ * output per recruit; the template searches for them by penalising
+ * SPR(F)/SPR(0) against that fraction (section 13, JNLL_REFPT_PENALTY).
+ *
+ * Both functions work on the female schedule (sex index 0) and scale by the
+ * proportion female at age, so a two-sex model takes its sex ratio as fixed.
+ *
+ * Not defined under predation: total mortality then carries M2, which scales
+ * with predator abundance, so spawning output per recruit is not a property of
+ * the prey stock alone. data_check() refuses the switch combinations that would
+ * read it.
+ */
+
+
+/**
+ * @brief Survivors at age from one recruit under a fixed mortality schedule.
+ *
+ * The oldest bin is a plus group, so it also accumulates the tail of survivors
+ * that stay in it: `/ (1 - exp(-Z_plus))`.
+ *
+ * Two unchecked preconditions, both inherited from the code this replaced and
+ * both left out of the AD path deliberately: `Z.size() >= 2`, since the plus
+ * group reads the age below it, and a plus-group `Z` above zero, or that tail
+ * divides by zero. No age-structured species reaches either.
+ *
+ * @param Z  Total instantaneous mortality at age (yr^-1), length nages >= 2.
+ * @return   Numbers at age per recruit.
+ */
+template <class Type>
+vector<Type> per_recruit_survivors(const vector<Type>& Z)
+{
+  int nages = Z.size();
+  vector<Type> n(nages);
+  n.setZero();
+  n(0) = 1.0;
+
+  for(int age = 1; age < nages - 1; age++){
+    n(age) = n(age - 1) * exp(-Z(age - 1));
+  }
+  n(nages - 1) = n(nages - 2) * exp(-Z(nages - 2)) / (1.0 - exp(-Z(nages - 1)));
+
+  return n;
+}
+
+
+/**
+ * @brief Female spawning biomass per recruit, given a survivor schedule.
+ *
+ * @param n            Numbers at age per recruit, from per_recruit_survivors().
+ * @param Z            The same mortality schedule that produced `n`, reused for
+ *                     the mortality served before spawning within the year.
+ * @param weight       Spawning weight at age (kg).
+ * @param maturity     Proportion mature at age.
+ * @param sex_ratio    Proportion female at age.
+ * @param spawn_month  Month of spawning, 0-12; 0 spawns at the start of the year.
+ * @return             Spawning biomass per recruit (kg per recruit).
+ */
+template <class Type>
+Type spawning_biomass_per_recruit(const vector<Type>& n,
+                                  const vector<Type>& Z,
+                                  const vector<Type>& weight,
+                                  const vector<Type>& maturity,
+                                  const vector<Type>& sex_ratio,
+                                  Type spawn_month)
+{
+  Type spr = 0.0;
+  for(int age = 0; age < n.size(); age++){
+    spr += n(age) * weight(age) * maturity(age) * sex_ratio(age) *
+      exp(-Z(age) * spawn_month / 12.0);
+  }
+  return spr;
+}
+
+#endif

--- a/tests/comparison/WHAM-SPR-comparison.R
+++ b/tests/comparison/WHAM-SPR-comparison.R
@@ -1,0 +1,107 @@
+# Spawning biomass per recruit: Rceattle vs WHAM ------------------------------
+#
+# Cross-check src/TMB/spr.hpp against an independent implementation. WHAM's
+# `get_SPR()` (R/wham_extra.R, unexported) is the reference: it is the routine
+# behind WHAM's own F40% search, written by a different author from a different
+# spec, so agreement is evidence about the formula rather than about our
+# transcription of it.
+#
+# The two use the same conventions, which is what makes the comparison exact
+# rather than approximate:
+#
+#   * plus group   WHAM does n[A] <- n[A-1]*exp(-Z[A-1]) then n[A]/(1-exp(-Z[A]));
+#                  spr.hpp's per_recruit_survivors() is the same expression.
+#   * spawn timing WHAM discounts by exp(-fracyrssb * Z[a]); Rceattle by
+#                  exp(-Z[a] * spawn_month/12), so fracyrssb = spawn_month/12.
+#   * F at age     WHAM takes a scalar F and multiplies by selectivity.
+#                  Rceattle builds Flimit_at_age as Flimit times the sum over
+#                  fishery fleets of sel * Proj_F_proportion, so that sum is the
+#                  selectivity WHAM's scalar F multiplies -- one fleet or three.
+#
+# The one difference is sex: WHAM is female-only and folds that into its
+# spawning weight, while Rceattle carries an explicit sex_ratio at age. It is
+# passed into WHAM's maturity argument here.
+#
+# Not part of test_check() -- it needs a WHAM install (see the other scripts in
+# this directory), and get_SPR is unexported, so calling it from tests/testthat
+# would put a ::: on another package into R CMD check.
+#
+# Result, Rceattle 5.12.0 vs WHAM 1.0.7.9000: 48 comparisons -- two datasets,
+# two spawn months, three species, four quantities -- worst relative difference
+# 2.22e-16, one ulp. GOA2018SS is the one that earns its place: nages differs
+# per species (10/21/12), species 3 has THREE fishery fleets, and species 1
+# ships a fractional spawn_month of 2.52.
+
+library(Rceattle)
+stopifnot(requireNamespace("wham", quietly = TRUE))
+wham_spr <- get("get_SPR", asNamespace("wham"))
+
+run_one <- function(ds, spawn_month) {
+  data(list = ds); d <- get(ds)
+  # Proportions must sum to 1 across each species' fishery fleets.
+  for (sp in seq_len(d$nspp)) {
+    f <- which(d$fleet_control$Fleet_type == 1 & d$fleet_control$Species == sp)
+    d$fleet_control$Proj_F_proportion[f] <- 1 / length(f)
+  }
+  if (!is.null(spawn_month)) d$spawn_month <- rep(spawn_month, d$nspp)
+
+  # initMode 3 is required: Finit is 0 in every other mode, and SPRFinit is
+  # then identically SPR0.
+  hcr <- build_hcr(HCR = 5, Ftarget = 0.4, Flimit = 0.35, Plimit = 0.2, Alpha = 0.05)
+  base <- suppressMessages(suppressWarnings(fit_mod(
+    data_list = d, estimateMode = 3, msmMode = 0, HCR = hcr,
+    initMode = "FishedNonEquilibrium",
+    fit_control = fit_control(getsd = FALSE, verbose = 0))))
+  # Three different rates, so the four quantities are distinct.
+  inits <- base$estimated_params
+  inits$log_Flimit  <- rep(log(0.25), length(inits$log_Flimit))
+  inits$log_Ftarget <- rep(log(0.15), length(inits$log_Ftarget))
+  inits$log_Finit   <- rep(log(0.10), length(inits$log_Finit))
+  fit <- suppressMessages(suppressWarnings(fit_mod(
+    data_list = d, inits = inits, estimateMode = 3, msmMode = 0, HCR = hcr,
+    initMode = "FishedNonEquilibrium",
+    fit_control = fit_control(getsd = FALSE, verbose = 0))))
+
+  q <- fit$quantities; dl <- fit$obj$env$data
+  nyrs_hind <- dl$endyr - dl$styr + 1L
+  Finit <- exp(fit$estimated_params$log_Finit)
+  frac  <- dl$spawn_month / 12
+  worst <- 0
+
+  for (sp in seq_along(dl$nages)) {
+    na <- dl$nages[sp]; ages <- seq_len(na)
+    wt_idx <- 2 * (sp - 1) + 2                     # C++ wt_idx_ssb = 2*sp + 1, 0-based
+    flts <- which(dl$flt_type == 1 & dl$flt_spp + 1L == sp)
+    sel <- rowSums(vapply(flts, function(f)
+      q$sel_at_age[f, 1, ages, nyrs_hind] * d$fleet_control$Proj_F_proportion[f],
+      numeric(na)))
+
+    M_end <- q$M_at_age[sp, 1, ages, nyrs_hind]
+    M_one <- q$M_at_age[sp, 1, ages, 1]
+    wt_end <- q$weight_hat[wt_idx, 1, ages, nyrs_hind]
+    wt_one <- q$weight_hat[wt_idx, 1, ages, 1]
+    mat <- dl$maturity[sp, ages] * dl$sex_ratio[sp, ages]   # WHAM has no sex term
+
+    cmp <- c(
+      SPR0      = q$SPR0[sp]      / wham_spr(0,              M_end, sel, mat, wt_end, frac[sp]),
+      SPRlimit  = q$SPRlimit[sp]  / wham_spr(q$Flimit[sp],   M_end, sel, mat, wt_end, frac[sp]),
+      SPRtarget = q$SPRtarget[sp] / wham_spr(q$Ftarget[sp],  M_end, sel, mat, wt_end, frac[sp]),
+      # Finit is flat across ages, not selectivity-scaled, and reads year 1.
+      SPRFinit  = q$SPRFinit[sp]  / wham_spr(Finit[sp], M_one, rep(1, na), mat, wt_one, frac[sp]))
+    worst <- max(worst, abs(cmp - 1))
+  }
+  cat(sprintf("%-10s nages=%-10s fishery fleets=%-8s spawn=%-14s worst rel diff %.3e\n",
+              ds, paste(dl$nages, collapse = "/"),
+              paste(tabulate(dl$flt_spp[dl$flt_type == 1] + 1L, dl$nspp), collapse = "/"),
+              paste(signif(dl$spawn_month, 3), collapse = "/"), worst))
+  worst
+}
+
+worst_all <- 0
+for (ds in c("BS2017SS", "GOA2018SS")) {
+  for (sm in list(NULL, 5)) worst_all <- max(worst_all, run_one(ds, sm))
+}
+
+cat(sprintf("\nworst relative difference across all 48 comparisons: %.3e\n", worst_all))
+stopifnot(worst_all < 1e-10)
+cat("Rceattle and WHAM agree on all four per-recruit quantities.\n")

--- a/tests/testthat/README.md
+++ b/tests/testthat/README.md
@@ -11,7 +11,7 @@ Files are flat (no subfolders) because `testthat` only auto-discovers tests dire
 | Prefix | What it covers | Main source under test |
 |--------|----------------|------------------------|
 | `test-data-*`        | Input assembly & validation: `clean_data` → `switch_check` → `data_check`, optional fields, combining data sets | `R/0-clean_data.R`, `R/1-data_check.R`, `R/0-combine_data_sets.R`, `R/0-switches.R` |
-| `test-dynamics-*`    | Population dynamics: recruitment, initial age structure, biological reference points (BRPs), multi-species fits, recruitment linkage | `R/6-fit_mod.R`, `R/5-rearrange_data.R`, `src/TMB/ceattle.cpp`, `src/TMB/recruitment.hpp` |
+| `test-dynamics-*`    | Population dynamics: recruitment, initial age structure, biological reference points (BRPs), spawning biomass per recruit, multi-species fits, recruitment linkage | `R/6-fit_mod.R`, `R/5-rearrange_data.R`, `src/TMB/ceattle.cpp`, `src/TMB/recruitment.hpp`, `src/TMB/spr.hpp` |
 | `test-growth-*`      | Growth curves (von Bertalanffy / Richards), CAAL, plus-group continuity, minage = 0, size-based selectivity | `src/TMB/growth.hpp`, `R/0-build_linkage.R` (`build_growth`) |
 | `test-likelihood-*`  | Observation likelihoods: index, composition (multinomial / Dirichlet-multinomial), diet, expected composition, OSA residuals | `src/TMB/comp_osa.hpp`, `src/TMB/diet_data.hpp`, `R/6-osa_residuals.R`, `jnll_comp` rows |
 | `test-linkage-*`     | Covariate/environmental linkage: formula parsing, encoding, linkage table, priors & bounds, pooling, per-sex / per-species formulas | `R/0-build_linkage.R`, `R/0-linkage_encode.R`, `R/0-linkage_table.R`, `R/0-priors.R`, `src/TMB/linkage.hpp` |

--- a/tests/testthat/test-dynamics-spr.R
+++ b/tests/testthat/test-dynamics-spr.R
@@ -114,6 +114,19 @@ testthat::test_that("all four SPRs match an independent recomputation", {
                            tolerance = 1e-8, info = nm)
   }
 
+  # The reported slot labels have to match the order section 6.2 writes them in.
+  # Nothing downstream reads NbyageSPR, so a silent drift between the labels and
+  # the write order would surface only in someone's diagnostic plot. Survivorship
+  # falls as the F applied rises, which orders the four slots uniquely here
+  # (F = 0 < Finit 0.10 < Ftarget 0.15 < Flimit 0.25).
+  n <- fit$quantities$NbyageSPR
+  testthat::expect_equal(dimnames(n)[[1]], c("F0", "Flimit", "Ftarget", "Finit"))
+  surv <- vapply(c("F0", "Finit", "Ftarget", "Flimit"),
+                 function(lab) sum(n[lab, 1, seq_len(fit$obj$env$data$nages[1])]), numeric(1))
+  testthat::expect_true(all(diff(surv) < 0))
+  # Every slot starts at one recruit.
+  testthat::expect_equal(unname(n[, 1, 1]), rep(1, 4))
+
   # The four really are distinct under these rates, so the loop above compared
   # four different numbers rather than one repeated.
   got <- vapply(c("SPR0", "SPRlimit", "SPRtarget", "SPRFinit"),

--- a/tests/testthat/test-dynamics-spr.R
+++ b/tests/testthat/test-dynamics-spr.R
@@ -1,0 +1,250 @@
+# Spawning biomass per recruit, section 6.2 of the template.
+#
+# Four per-recruit quantities are built from the same survival recursion and
+# differ only in the mortality applied and the year the rates are read from:
+#
+#   SPR0       M only                            terminal hindcast year
+#   SPRlimit   M + Flimit_at_age  (at age)       terminal hindcast year
+#   SPRtarget  M + Ftarget_at_age (at age)       terminal hindcast year
+#   SPRFinit   M + Finit          (flat scalar)  FIRST year
+#
+# SPRFinit differing on both counts is the part that is easy to lose in a
+# refactor, so it is asserted explicitly here rather than inferred.
+#
+# `test-dynamics-brps.R` already checks SPR0 against a closed form, but on a
+# fixture with constant M, weight 1, maturity 1 and spawn_month 0 -- so it
+# cannot catch a dropped spawn-timing term, a maturity or sex-ratio
+# misindexing, or a wrong weight year. SPRlimit, SPRtarget and SPRFinit had no
+# direct assertion at all, and those three drive the reference-point penalties
+# and R_init. These tests exist so the section can be moved without silently
+# changing what it computes.
+
+# Rebuild SPR in R from the reported rates, with every index written out.
+.spr_by_hand <- function(fit, dat) {
+  q <- fit$quantities
+  d <- fit$obj$env$data
+  nyrs_hind <- d$endyr - d$styr + 1L
+  term <- nyrs_hind                       # 1-based terminal hindcast year
+  Finit <- exp(fit$estimated_params$log_Finit)
+
+  # Flimit/Ftarget at age are selectivity-weighted sums over fishery fleets,
+  # the way section 5.12 builds them.
+  f_at_age <- function(sp, yr, scale) {
+    out <- numeric(d$nages[sp])
+    for (flt in seq_along(d$flt_type)) {
+      if (d$flt_type[flt] != 1) next
+      if (d$flt_spp[flt] + 1L != sp) next
+      prop <- dat$fleet_control$Proj_F_proportion[flt]
+      out <- out + q$sel_at_age[flt, 1, seq_len(d$nages[sp]), yr] * prop * scale[sp]
+    }
+    out
+  }
+
+  out <- list()
+  for (sp in seq_along(d$nages)) {
+    na <- d$nages[sp]
+    wt_idx <- 2 * (sp - 1) + 2          # C++ wt_idx_ssb = 2*sp + 1, 0-based
+
+    M_term <- q$M_at_age[sp, 1, seq_len(na), term]
+    M_yr1  <- q$M_at_age[sp, 1, seq_len(na), 1]
+    Z <- list(
+      SPR0      = M_term,
+      SPRlimit  = M_term + f_at_age(sp, term, q$Flimit),
+      SPRtarget = M_term + f_at_age(sp, term, q$Ftarget),
+      SPRFinit  = M_yr1  + Finit[sp]
+    )
+    wt <- list(
+      SPR0      = q$weight_hat[wt_idx, 1, seq_len(na), term],
+      SPRlimit  = q$weight_hat[wt_idx, 1, seq_len(na), term],
+      SPRtarget = q$weight_hat[wt_idx, 1, seq_len(na), term],
+      SPRFinit  = q$weight_hat[wt_idx, 1, seq_len(na), 1]
+    )
+
+    for (nm in names(Z)) {
+      z <- Z[[nm]]
+      n <- numeric(na)
+      n[1] <- 1
+      for (a in 2:(na - 1)) n[a] <- n[a - 1] * exp(-z[a - 1])
+      # Plus group: survivors into it, then the infinite tail at its own Z.
+      n[na] <- n[na - 1] * exp(-z[na - 1]) / (1 - exp(-z[na]))
+      out[[nm]] <- c(out[[nm]],
+                     sum(n * wt[[nm]] * d$maturity[sp, seq_len(na)] *
+                           d$sex_ratio[sp, seq_len(na)] *
+                           exp(-z * d$spawn_month[sp] / 12)))
+    }
+  }
+  out
+}
+
+testthat::test_that("all four SPRs match an independent recomputation", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("TMB")
+
+  data("BS2017SS")
+  d <- BS2017SS
+  d$fleet_control$Proj_F_proportion <- rep(1, nrow(d$fleet_control))
+
+  # initMode "FishedNonEquilibrium" (3) is required: section 5.4 sets Finit to 0
+  # for every other mode, under which SPRFinit is identically SPR0. That is why
+  # a broken SPRFinit could go unnoticed -- no default configuration separates
+  # the two.
+  hcr  <- Rceattle::build_hcr(HCR = 5, Ftarget = 0.4, Flimit = 0.35,
+                              Plimit = 0.2, Alpha = 0.05)
+  base <- suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = d, estimateMode = 3, msmMode = 0, HCR = hcr,
+                      initMode = "FishedNonEquilibrium",
+                      fit_control = Rceattle::fit_control(getsd = FALSE, verbose = 0))))
+
+  # Distinct rates, so the four quantities cannot pass by coinciding. The
+  # shipped starting values are Flimit = Ftarget = 1 and Finit = exp(-10),
+  # under which SPRlimit == SPRtarget and SPRFinit is SPR0 to seven decimals.
+  inits <- base$estimated_params
+  inits$log_Flimit  <- rep(log(0.25), length(inits$log_Flimit))
+  inits$log_Ftarget <- rep(log(0.15), length(inits$log_Ftarget))
+  inits$log_Finit   <- rep(log(0.10), length(inits$log_Finit))
+
+  fit <- suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = d, inits = inits, estimateMode = 3, msmMode = 0,
+                      HCR = hcr, initMode = "FishedNonEquilibrium",
+                      fit_control = Rceattle::fit_control(getsd = FALSE, verbose = 0))))
+
+  want <- .spr_by_hand(fit, d)
+  for (nm in c("SPR0", "SPRlimit", "SPRtarget", "SPRFinit")) {
+    testthat::expect_equal(as.numeric(fit$quantities[[nm]]), want[[nm]],
+                           tolerance = 1e-8, info = nm)
+  }
+
+  # The four really are distinct under these rates, so the loop above compared
+  # four different numbers rather than one repeated.
+  got <- vapply(c("SPR0", "SPRlimit", "SPRtarget", "SPRFinit"),
+                function(nm) as.numeric(fit$quantities[[nm]])[1], numeric(1))
+  testthat::expect_equal(length(unique(signif(got, 8))), 4L)
+  # More fishing removes spawning output: SPR0 is the largest.
+  testthat::expect_true(all(got[-1] < got[["SPR0"]]))
+})
+
+testthat::test_that("SPR carries spawn timing, maturity and the weight year", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("TMB")
+
+  # A closed form on a controlled fixture: constant M, so the recursion is
+  # writable by hand, but a non-zero spawn month and a real maturity ogive, so
+  # dropping either term fails. `test-dynamics-brps.R` sets both to their
+  # neutral values and cannot see them.
+  data("GOA2018SS")
+  g <- GOA2018SS
+  g$M1_base[, 3:32] <- 0.2
+  g$weight[, 6:35]  <- 1
+  g$sex_ratio[, -1] <- 0.5
+  g$spawn_month     <- rep(4, g$nspp)      # spawning a third of the way through
+  mat <- c(0, 0.1, 0.5, 0.9, rep(1, 30))   # knife-ish ogive, not all ones
+  for (sp in seq_len(g$nspp)) g$maturity[sp, -1] <- mat[seq_len(ncol(g$maturity) - 1)]
+
+  fit <- suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = g, estimateMode = 3, msmMode = 0,
+                      fit_control = Rceattle::fit_control(getsd = FALSE, verbose = 0))))
+
+  M <- 0.2
+  for (sp in seq_len(g$nspp)) {
+    na <- fit$obj$env$data$nages[sp]
+    n <- numeric(na)
+    n[1] <- 1
+    for (a in 2:(na - 1)) n[a] <- n[a - 1] * exp(-M)
+    n[na] <- n[na - 1] * exp(-M) / (1 - exp(-M))
+    want <- sum(n * 1 * mat[seq_len(na)] * 0.5 * exp(-M * 4 / 12))
+    testthat::expect_equal(as.numeric(fit$quantities$SPR0)[sp], want,
+                           tolerance = 1e-6, info = paste("species", sp))
+  }
+})
+
+testthat::test_that("NbyageSPR is zero where it is never filled", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("TMB")
+
+  # Two holes the recursion never writes: ages past a species' own nages when
+  # another species is longer-lived, and every element under multispecies mode,
+  # where section 6.2 does not run at all. Both are reported, so both are read.
+  data("BS2017SS")
+  ss <- suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = BS2017SS, estimateMode = 3, msmMode = 0,
+                      fit_control = Rceattle::fit_control(getsd = FALSE, verbose = 0))))
+  nages <- ss$obj$env$data$nages
+  max_age <- dim(ss$quantities$NbyageSPR)[3]
+  testthat::expect_gt(max_age, min(nages))          # the ragged case exists here
+  for (sp in seq_along(nages)) {
+    if (nages[sp] >= max_age) next
+    tail_ages <- (nages[sp] + 1):max_age
+    testthat::expect_true(all(ss$quantities$NbyageSPR[, sp, tail_ages] == 0),
+                          info = paste("species", sp))
+  }
+
+  data("BS2017MS")
+  ms <- suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = BS2017MS, estimateMode = 3, msmMode = 1,
+                      fit_control = Rceattle::fit_control(getsd = FALSE, verbose = 0))))
+  testthat::expect_true(all(ms$quantities$NbyageSPR == 0))
+  testthat::expect_true(all(ms$quantities$SPR0 == 0))
+})
+
+testthat::test_that("a stock-recruit curve that needs SPR is refused under predation", {
+  testthat::skip_if_not_installed("TMB")
+
+  # Section 6.2 does not compute SPR under predation, on purpose: total
+  # mortality carries M2, so per-recruit spawning output is not a property of
+  # the prey stock alone. Section 6.3 read it anyway.
+  #
+  #   srr_fun >= 2                        SPR0 = 0, so R0 = (alpha - 1/0)/beta
+  #                                       is -Inf and the objective is NaN.
+  #   srr_fun < 2, srr_pred_fun >= 2      the Ianelli configuration, and the
+  #                                       dangerous one: the fit RUNS, with
+  #                                       steepness 0, R_hat -Inf and a finite
+  #                                       objective.
+  data("BS2017MS")
+
+  for (cfg in list(list(f = "BevertonHolt", p = "BevertonHolt"),
+                   list(f = "Ricker",       p = "Ricker"),
+                   list(f = "mean",         p = "BevertonHolt"))) {
+    srr <- suppressWarnings(Rceattle::build_srr(
+      srr_fun = cfg$f, srr_pred_fun = cfg$p, proj_mean_rec = TRUE,
+      srr_est_mode = "Fixed", srr_prior = 0.8))
+    testthat::expect_error(
+      suppressMessages(suppressWarnings(
+        Rceattle::fit_mod(data_list = BS2017MS, estimateMode = 3, msmMode = 1,
+                          recFun = srr,
+                          fit_control = Rceattle::fit_control(verbose = 0)))),
+      "spawning biomass per recruit",
+      info = paste(cfg$f, cfg$p))
+  }
+
+  # Mean recruitment is unaffected, and so is the same curve single-species.
+  data("BS2017SS")
+  testthat::expect_no_error(suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = BS2017MS, estimateMode = 3, msmMode = 1,
+                      fit_control = Rceattle::fit_control(verbose = 0)))))
+
+  # srr_fun can still be the canonical string here. fit_mod() coerces it --
+  # with recFun = NULL it rebuilds the default and the string never survives --
+  # but data_check() is documented as the way to validate a data_list on its
+  # own, so it has to read the string form correctly. This is the case that
+  # matters: R compares "mean" >= 2 as characters and calls it TRUE, so a guard
+  # reading the raw value refuses a good mean-recruitment multispecies model.
+  # switch_check() first, as fit_mod() does -- it normalises the fleet_control
+  # switches but leaves srr_fun alone, which is exactly how a string reaches
+  # data_check().
+  d_str <- suppressMessages(suppressWarnings(switch_check(BS2017MS)))
+  d_str$msmMode <- 1
+  d_str$srr_fun <- d_str$srr_pred_fun <- "mean"
+  testthat::expect_no_error(suppressMessages(suppressWarnings(data_check(d_str))))
+
+  d_bh <- d_str
+  d_bh$srr_fun <- d_bh$srr_pred_fun <- "BevertonHolt"
+  testthat::expect_error(suppressMessages(suppressWarnings(data_check(d_bh))),
+                         "spawning biomass per recruit")
+  srr_bh <- suppressWarnings(Rceattle::build_srr(
+    srr_fun = "BevertonHolt", srr_pred_fun = "BevertonHolt", proj_mean_rec = TRUE,
+    srr_est_mode = "Fixed", srr_prior = 0.8))
+  testthat::expect_no_error(suppressMessages(suppressWarnings(
+    Rceattle::fit_mod(data_list = BS2017SS, estimateMode = 3, msmMode = 0,
+                      recFun = srr_bh,
+                      fit_control = Rceattle::fit_control(verbose = 0)))))
+})


### PR DESCRIPTION
Targets `dev`, which now carries the whole #112–#115 stack.

Four commits, in the order the work had to happen: pin, move, fix what pinning exposed, then
label the one reported object this touches.

## Why

Section 6.2 built `SPR0`, `SPRlimit`, `SPRtarget` and `SPRFinit` from one survival recursion
written out **four times, at four separate stages** — initialise, age loop, plus group,
accumulate. Sixteen of its 39 lines were that copy-paste, and the two plus-group lines were
**302 and 304 characters**.

The repetition was the visible problem. The real one is that the four cases are **not
symmetric**, and the asymmetry was invisible:

| | F applied | year the rates are read from |
|---|---|---|
| `SPR0` | none | terminal hindcast |
| `SPRlimit` | `Flimit_at_age` (selectivity-scaled) | terminal hindcast |
| `SPRtarget` | `Ftarget_at_age` (selectivity-scaled) | terminal hindcast |
| `SPRFinit` | `Finit` — **flat scalar** | **year 1**, mortality *and* weight |

`SPRFinit` differs on both counts, and reading that off the old code meant diffing two
300-character lines character by character.

## 1. Pin — `d0bc1583`

Only `SPR0` was tested, by `test-dynamics-brps.R`, on a fixture with constant M, weight 1,
maturity 1, sex_ratio 0.5 and `spawn_month` 0 — every term that could go wrong set to its
neutral value. `SPRlimit`, `SPRtarget` and `SPRFinit` had **no direct assertion at all**, and
those three drive the reference-point penalties and `R_init`.

`tests/testthat/test-dynamics-spr.R` recomputes all four in R with the year indices and
plus-group form written out; checks `SPR0` against a closed form on a fixture that *keeps* a
non-zero spawn month and a real maturity ogive; and pins `NbyageSPR`'s zeros.

`tests/comparison/WHAM-SPR-comparison.R` checks the formula against **WHAM's `get_SPR()`**, an
independent implementation. The conventions line up exactly — same plus-group expression, same
within-year spawn discount, and WHAM's scalar-F-times-selectivity is Rceattle's
`Flimit_at_age` with the per-fleet proportions folded in — so this is an equality, not a
correlation.

**48 comparisons, worst relative difference 2.22e-16 (one ulp).**

| dataset | nages | fishery fleets/species | spawn month |
|---|---|---|---|
| BS2017SS | 12/12/21 | 1/1/1 | 0, then 5 |
| GOA2018SS | 10/21/12 | **1/1/3** | **2.52**/0/0, then 5 |

GOA2018SS carries the cases worth having: three fishery fleets on one species tests the
multi-fleet F sum, and a fractional `spawn_month` tests the timing discount off an integer.

**Recorded while writing this:** `SPRFinit` is identically `SPR0` unless `initMode` is 3 or 4,
because section 5.4 zeroes `Finit` for every other mode. No default configuration separates
them, which is how an untested `SPRFinit` went unnoticed.

The unit tests are mutation-checked: dropping the `exp(-Z * spawn_month/12)` term, and reading
`SPRFinit`'s weight from the terminal year instead of year 1, each fail here.
`test-dynamics-brps.R` passes both mutations unchanged.

## 2. Move — `9310969d`

`per_recruit_survivors()` and `spawning_biomass_per_recruit()` in `src/TMB/spr.hpp`; the block
assembles the four mortality schedules and calls them by name. `NbyageSPR` is also zeroed at
declaration, which it was not — it measured zero on this toolchain, so nothing was wrong, but
it was the one array here not saying so.

**Honest accounting, because "refactor" implies a saving that isn't there.** Code characters go
2294 → 2234 (−3%) and *lines* go **up** by 8 at the call site. What actually improves: no
300-character lines (longest is now 110), the recursion and plus-group formula exist once
instead of four times, the `SPRFinit` asymmetry is four named variables instead of buried at
character 180, and the formula is externally verified once rather than four times by eye.

**Not bit-identical under optimisation.** At fixed parameters it is — BS2017SS, BS2017SS under
a Tier-3 HCR with the three rates set apart, GOA2018SS and BS2017MS all return identical
`SPR0`, `SPRlimit`, `SPRtarget`, `SPRFinit`, `NbyageSPR`, `steepness`, `R0`, `ssb`, `SB0`,
`SBF`, `jnll_comp` and objective. Fits that *engage the reference-point penalty* land a little
away: BS2017SS at `estimateMode = 0` under a Tier-3 HCR moves 1.3e-05 in the objective
(1.3e-09 relative), and Pacific hake's category-1 HCR stage moves 1.8e-06 (8.3e-10). The
likely mechanism is codegen — the expressions are algebraically identical, but the compiler may
associate a helper differently from inlined code, and the penalty locates F on a flat ridge
where `SPR(F)/SPR0` equals the target, which turns a last-bit change into a sqrt(eps)-sized
move.

If that is not acceptable for a refactor, this commit reverts cleanly and 1 and 3 stand alone.

## 3. Fix what pinning exposed — `4252551e`

Section 6.2 declines to compute SPR under predation, and **that is correct**: total mortality
carries `M2`, which scales with predator abundance, so spawning output per recruit is not a
property of the prey stock alone. Section 6.3 consumes it regardless, and was never gated to
match.

The damage split two ways, and the quieter half is worse:

| configuration | what happened |
|---|---|
| `srr_fun >= 2` | `SPR0 = 0`, so `R0 = (alpha - 1/SPR0)/beta` is `-Inf`, `R_init` `-Inf`, `steepness` 0, objective `NaN` |
| `srr_fun` mean, `srr_pred_fun >= 2` | the Ianelli configuration. **The fit runs.** BS2017MS returns a finite objective of 1929328 with `steepness` silently 0 and `R_hat` `-Inf` |

Both measured on BS2017MS at `msmMode = 1`. `data_check()` now refuses both, naming spawning
biomass per recruit. Nothing that produced a usable fit is refused — `SPR0` was 0 in every case
this catches.

Not fixed by computing SPR under predation, which is the other way to close it: a per-recruit
reference point built on a mortality that moves with predator abundance is a number without a
defensible meaning, which is worse than refusing the configuration.

The switch is resolved through `.SRR_FUNS` rather than compared raw. `fit_mod()` coerces
`srr_fun` to its integer code, but `data_check()` is documented as the way to validate a
`data_list` on its own, and there the canonical string survives — and in R **`"mean" >= 2` is
`TRUE`**, a character comparison. The first draft of this commit read the raw value and would
have refused good mean-recruitment multispecies models; the adversarial review caught it and
the test covers both string forms.

## 4. Label — `4135fa71`

`NbyageSPR` is the only numbers-at-age array `rename_output()` left without dimension names,
and the only reported quantity whose first dimension is a reference point rather than a
species — reading it meant knowing that slot 3 is `Finit`. It now carries
`c("F0", "Flimit", "Ftarget", "Finit")`, species, and age bins.

**Labelled rather than restructured, deliberately.** Nothing in the package or in
`../Rceattle-models` reads `NbyageSPR`, so a different shape buys no caller anything, while
renaming or splitting a REPORTed quantity would owe a deprecation path for an object with no
users. It is also small — `4 x nspp x max_age`, about 2 KB for BS2017SS — so the ragged padding
costs bytes, not correctness. Per-recruit survivorship at age is a real diagnostic; the fix is
to make it legible.

Ages use the same `paste0("Age", 1:max_age)` as the eleven sibling arrays, so the label is the
age bin index and equals the age only when `minage` is 1 — following the convention rather than
inventing a second one for a single array.

The labels are pinned behaviourally, since drift between them and the write order would surface
only in someone's diagnostic plot: survivorship falls as the F applied rises, so with F = 0,
`Finit` 0.10, `Ftarget` 0.15 and `Flimit` 0.25 the summed survivorship comes out
**2.407 > 2.012 > 1.880 > 1.688**, and the test asserts that ordering along with the names.

## Verification

- **Full suite: 161 files, 0 failures** (`TESTTHAT_PARALLEL=false`), re-run after each commit.
- **Golden**: all four reference models reproduce their pinned objectives.
- **WHAM**: 48 comparisons at 2.22e-16, before and after the move.
- **`../Rceattle-models/Pacific hake/04-mse.R`** end to end — four staged fits plus
  `run_mse()`. Single-species, MSVPA and estimated-suitability stages are bit-identical to
  `dev`; the category-1 HCR stage moves as above, and `mse_summary()`'s metrics move at most
  3.1e-05 relative (on `catch_iav`), with terminal SSB and depletion agreeing to eight
  significant figures.

## Left alone deliberately

`spr.hpp` documents two preconditions rather than branching in the AD path on every evaluation:
`nages >= 2`, since the plus group reads the age below it, and a plus-group `Z` above zero, or
the `1/(1 - exp(-Z))` tail divides by zero. `data_check()` enforces neither today; both are
inherited from the code this replaces, and no age-structured species reaches either.

The `sex_ratio`-is-fixed-for-two-sex-models note stays a FIXME — it is a modelling decision,
not a transcription one.

Housekeeping: a stale `dev/golden-ref.rds` captured before commit 4 will now differ by
`NbyageSPR`'s dimnames if you diff full fit objects with the `/golden-check` scratch recipe.
That file is gitignored and the recipe already says to capture the baseline before the change;
`test-golden-regression.R`, which pins objectives, is unaffected.
