### PR TITLE
Let run_mse() take an assessment schedule and a year-indexed catch multiplier

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rceattle
 Title: Fits the Multispecies Assessment Model (CEATTLE) Using TMB
-Version: 5.16.0
+Version: 5.17.0
 Authors@R:
     person(given = "Grant",
            family = "Adams",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,90 @@ intermediate. Note the folding rather than renumbering: a section for a version 
 never carries breaks any (x.y.z) cross-reference pointing at it.
 -->
 
+# Rceattle 5.17.0
+
+## MSE
+
+* **`run_mse(assessment_period =)` takes an explicit vector of assessment
+  years.** A single number is the period it always was; a vector is the
+  schedule itself — the exact years an assessment is completed.
+
+  A skipped assessment is one gap in an otherwise regular cycle, and a period
+  cannot express it. Standing in a triennial period for a missed biennial
+  assessment answers a different question and the error does not have a
+  known sign: a permanent longer cycle overstates how the cost of stale advice
+  compounds, while being blind to the state the stock happened to be in when
+  the single gap opened.
+
+  ```r
+  biennial <- seq(om$data_list$endyr + 2, om$data_list$projyr, by = 2)
+  run_mse(om, em, assessment_period = setdiff(biennial, 2031))
+  ```
+
+  Every year must be after the operating model's terminal year and within the
+  projection horizon (the earlier of the two models' `projyr` and `endyr`).
+  A year outside that window is an error rather than being dropped: dropping it
+  would run a schedule the caller did not ask for, with nothing in the returned
+  object to say so. The years are sorted and de-duplicated, and the assessment
+  nodes carry them in their names, as they already did.
+
+  A schedule must name **two or more** years: one year on its own cannot be
+  told from a period, and the two readings of, say, `2029` are a world apart.
+  It is refused with a message saying which reading was taken, rather than
+  guessed at.
+
+  A scalar is also now required to be a whole year of at least 1, and to leave
+  room for at least one assessment inside the projection. A fractional period
+  set the operating model's terminal year to a fraction, which nothing
+  downstream indexes on; a period longer than the projection used to surface as
+  `seq()` reporting on the sign of its `by` argument. Nothing that produced a
+  usable number is refused.
+
+* **`run_mse(catch_mult =)` takes a `data.frame` of `Year`, `Species` and
+  `mult`.** A single number or a vector of length `nspp` is unchanged and
+  applies in every projection year. A `data.frame` applies only in the year and
+  species pairs it lists; every pair it omits is multiplied by 1.
+
+  The vector form is a permanent harvest cut, so it cannot express a buffer
+  held only while advice is stale — the case a missed assessment raises.
+
+  ```r
+  buffer <- expand.grid(Year = 2031:2032, Species = seq_len(om$data_list$nspp))
+  buffer$mult <- 0.90
+  run_mse(om, em, assessment_period = setdiff(biennial, 2031),
+          catch_mult = buffer)
+  ```
+
+  `Species` is the species number, matching the catch data's own column.
+  The table is validated at the call rather than inside the simulation loop: a
+  year outside the projection, a species number out of range, a non-finite or
+  negative multiplier, and two rows for the same year and species are all
+  errors. Each of those otherwise reads as *no reduction* — `match()` returns
+  `NA` for an unmatched pair and takes the first of a duplicated one — in a run
+  that finishes and looks ordinary. A vector `catch_mult` is now checked for
+  finiteness and sign for the same reason.
+
+  Note that this multiplies **catch**, not the ABC the control rule produces.
+  Where realized catch sits well below ABC — GOA arrowtooth flounder, for one —
+  reducing ABC changes removals only to the extent the fishery attains it,
+  while reducing catch changes them in full. Scale the multiplier by recent
+  attainment, `1 - (1 - mult) * attainment`, or report the unscaled result as an
+  upper bound on the effect of the reduction. `?run_mse` and
+  `vignette("hcrs-and-mses")` both carry the caveat.
+
+* No stored MSE result changes. `assessment_period = 1` and a scalar
+  `catch_mult` take the same paths they did, and `tools/verify/verify-mse-schedule.R`
+  checks that a schedule given as years reproduces the equivalent period exactly.
+
+## Documentation
+
+* `vignette("hcrs-and-mses")` gains a worked missed-assessment scenario, and its
+  reproducibility section now names **5.13.0** alongside 5.9.0. Both moved the
+  random-number stream — 5.9.0 by moving the observation draws from R into the
+  template, 5.13.0 by drawing the index under the fleet's own
+  `Index_distribution` — so a seeded `run_mse()` reproduces across neither.
+
+
 # Rceattle 5.16.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,23 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
   `seq()` reporting on the sign of its `by` argument. Nothing that produced a
   usable number is refused.
 
+* **A schedule that stops short of the projection horizon now warns.** Catch is
+  only ever filled up to the last assessment, so the trailing years keep the
+  `NA` their projection rows were created with — and `mse_summary()` summarises
+  over the models' whole projection regardless. Those `NA` years sit in the
+  denominator of `P(Closed)` but not its numerator, in both halves of
+  `Catch IAV`, and outside the `na.rm` mean that is `Average Catch`. All three
+  come out low, with nothing in the table saying which years were covered.
+
+  A biennial cycle over an odd number of projection years lands here every
+  time: `seq(2027, 2050, by = 2)` ends at 2049 against a 2050 horizon. The
+  warning names the years and both fixes — extend the schedule, or set `projyr`
+  to the last assessment year.
+
+  Warned rather than refused, because a short schedule is a legitimate design;
+  it just has to be summarised over the years it covers. This fires for a
+  scalar period too, where the defect is older than the vector API.
+
 * **`run_mse(catch_mult =)` takes a `data.frame` of `Year`, `Species` and
   `mult`.** A single number or a vector of length `nspp` is unchanged and
   applies in every projection year. A `data.frame` applies only in the year and
@@ -67,9 +84,11 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
 
   `Species` is the species number, matching the catch data's own column.
   The table is validated at the call rather than inside the simulation loop: a
-  year outside the projection, a species number out of range, a non-finite or
-  negative multiplier, and two rows for the same year and species are all
-  errors. Each of those otherwise reads as *no reduction* — `match()` returns
+  year the assessment schedule does not cover, a species number out of range, a
+  non-finite or negative multiplier, and two rows for the same year and species
+  are all errors. The year bound is the **last assessment year**, not `projyr`
+  — catch is filled only up to the last assessment, so a multiplier named for a
+  later year is inside the projection and still applies nowhere. Each of those otherwise reads as *no reduction* — `match()` returns
   `NA` for an unmatched pair and takes the first of a duplicated one — in a run
   that finishes and looks ordinary. A vector `catch_mult` is now checked for
   finiteness and sign for the same reason.

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,11 +76,18 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
   held only while advice is stale — the case a missed assessment raises.
 
   ```r
-  buffer <- expand.grid(Year = 2031:2032, Species = seq_len(om$data_list$nspp))
+  buffer <- expand.grid(Year = 2032:2033, Species = seq_len(om$data_list$nspp))
   buffer$mult <- 0.90
   run_mse(om, em, assessment_period = setdiff(biennial, 2031),
           catch_mult = buffer)
   ```
+
+  Mind which years are the stale ones. The assessment in year `Y` sets catch
+  for `Y+1` onward, so a missed 2031 assessment leaves **2032 and 2033** on
+  2029's advice. 2031 is set by the 2029 assessment whether or not the 2031 one
+  happens, so cutting it changes a year the gap never touched while leaving a
+  genuinely stale year uncut. `?run_mse` and the vignette both show the
+  derivation.
 
   `Species` is the species number, matching the catch data's own column.
   The table is validated at the call rather than inside the simulation loop: a
@@ -104,6 +111,26 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
 * No stored MSE result changes. `assessment_period = 1` and a scalar
   `catch_mult` take the same paths they did, and `tools/verify/verify-mse-schedule.R`
   checks that a schedule given as years reproduces the equivalent period exactly.
+
+* **Documented: two schedules on the same `seed` are not on common random
+  numbers.** Between assessments the operating model's projection horizon is
+  shortened to the next assessment year, so `sim_mod()` draws over a different
+  number of projection rows depending on the schedule, and the observation
+  draws diverge from the first assessment onward. Recruitment deviations are
+  shared — `sample_rec()` draws them before the loop — but observation error is
+  not.
+
+  Measured on a three-year BS2017SS fixture: dropping one assessment moved
+  catch by **2.1%** in a year whose advice was identical by construction, set
+  by the same earlier assessment under both schedules. A paired comparison of
+  two schedules therefore carries an observation-error difference alongside the
+  schedule effect.
+
+  Pre-existing, and not changed here — the fix would move every seeded
+  `run_mse()` result. But the vector schedule exists to compare schedules, so
+  the limitation now sits in `?run_mse`, in `vignette("hcrs-and-mses")`, and as
+  a pinned check in `verify-mse-schedule.R` that fails if the draw is ever made
+  schedule-independent.
 
 ## Documentation
 

--- a/R/10-run_mse.R
+++ b/R/10-run_mse.R
@@ -160,7 +160,12 @@
 #
 # `max_yr` is the last year an assessment can be run in: the earlier of the two
 # models' projection horizons, and of `endyr` where the caller set one.
-.mse_assess_years <- function(assessment_period, om_endyr, max_yr) {
+# `proj_last` is the horizon mse_summary() reads, which is the two models' own
+# projyr and takes no notice of `endyr` -- so the two differ whenever the caller
+# shortens the MSE, and the short-schedule warning has to test against the
+# second.
+.mse_assess_years <- function(assessment_period, om_endyr, max_yr,
+                              proj_last = max_yr) {
   if (!is.numeric(assessment_period) || length(assessment_period) == 0 ||
       anyNA(assessment_period)) {
     stop("`assessment_period` must be a number of years, or a vector of the ",
@@ -195,7 +200,7 @@
     return(.mse_warn_short_schedule(
       seq(from = om_endyr + assessment_period, to = max_yr,
           by = assessment_period),
-      max_yr))
+      proj_last))
   }
 
   # * An explicit schedule ----
@@ -221,7 +226,7 @@
          call. = FALSE)
   }
 
-  .mse_warn_short_schedule(assess_yrs, max_yr)
+  .mse_warn_short_schedule(assess_yrs, proj_last)
 }
 
 # A schedule that stops short of the projection horizon leaves the trailing
@@ -237,20 +242,25 @@
 #
 # Warned rather than refused: a schedule that stops short is a legitimate
 # design, it just has to be summarised over the years it covers.
-.mse_warn_short_schedule <- function(assess_yrs, max_yr) {
+#
+# Tested against `proj_last`, the models' own projyr, NOT the last year an
+# assessment may run in. `endyr` shortens the second and not the first, so a
+# caller who ends the MSE early leaves every remaining projection year unfished
+# -- the same understatement, over more years.
+.mse_warn_short_schedule <- function(assess_yrs, proj_last) {
   last <- max(assess_yrs)
-  if (last < max_yr) {
-    unfished <- if (last + 1 == max_yr) {
-      as.character(max_yr)
+  if (last < proj_last) {
+    unfished <- if (last + 1 == proj_last) {
+      as.character(proj_last)
     } else {
-      paste0(last + 1, "-", max_yr)
+      paste0(last + 1, "-", proj_last)
     }
-    warning("The last assessment is in ", last, " but the projection runs to ",
-            max_yr, ", so catch in ", unfished, " is never set. Those years ",
+    warning("The last assessment is in ", last, " but the models project to ",
+            proj_last, ", so catch in ", unfished, " is never set. Those years ",
             "carry NA, and mse_summary() understates Average Catch, Catch IAV ",
             "and P(Closed) because it summarises over the whole projection. ",
-            "Either extend the schedule to ", max_yr, ", or set projyr to ",
-            last, " in both models.", call. = FALSE)
+            "Either set projyr to ", last, " in both models, or run ",
+            "assessments through ", proj_last, ".", call. = FALSE)
   }
   assess_yrs
 }
@@ -390,6 +400,18 @@
 #' from a period, and the two readings are a world apart, so it is refused
 #' rather than guessed at.
 #'
+#' Two schedules run on the same `seed` are **not** on common random numbers.
+#' Between assessments the operating model's projection horizon is shortened to
+#' the next assessment year, so `sim_mod()` draws over a different number of
+#' projection rows depending on the schedule, and the observation draws diverge
+#' from the first assessment onward. On a three-year BS2017SS fixture, dropping
+#' one assessment moved catch in a year whose advice was identical by
+#' construction by 2.1%. A paired comparison of two schedules therefore carries
+#' an observation-error difference alongside the schedule effect; treat the
+#' difference as containing Monte Carlo noise, and use enough replicates to
+#' separate the two rather than relying on variance reduction that is not
+#' there.
+#'
 #' Make the last assessment year reach the projection horizon. Catch is only
 #' ever filled up to the last assessment, so a schedule that stops short leaves
 #' the trailing years at `NA`, and `mse_summary()` summarises over the whole
@@ -403,10 +425,15 @@
 #' `catch_mult` multiplies the catch the estimation model's control rule
 #' recommends, before `cap` and before the exploitable-biomass limit. Given as
 #' a `data.frame` it applies only in the years and species it lists, which is
-#' how a buffer held for the years advice is stale is expressed:
+#' how a buffer held for the years advice is stale is expressed.
+#'
+#' Mind which years those are. The assessment in year `Y` sets catch for `Y+1`
+#' onward, so a missed assessment in 2031 leaves **2032 and 2033** on 2029's
+#' advice --- 2031 itself is set by the 2029 assessment either way, and cutting
+#' it changes a year the missed assessment never touched:
 #'
 #' ```
-#' buffer <- expand.grid(Year = 2031:2032, Species = seq_len(om$data_list$nspp))
+#' buffer <- expand.grid(Year = 2032:2033, Species = seq_len(om$data_list$nspp))
 #' buffer$mult <- 0.90
 #' run_mse(om, em, assessment_period = setdiff(biennial, 2031),
 #'         catch_mult = buffer)
@@ -519,9 +546,10 @@ run_mse <- function(om, em, nsim = 10, start_sim = 1, assessment_period = 1, sam
   # - Assessment period, or an explicit schedule of assessment years
   assess_yrs <- .mse_assess_years(
     assessment_period,
-    om_endyr = om$data_list$endyr,
-    max_yr   = min(c(om$data_list$projyr, em$data_list$projyr, endyr),
-                   na.rm = TRUE))
+    om_endyr  = om$data_list$endyr,
+    max_yr    = min(c(om$data_list$projyr, em$data_list$projyr, endyr),
+                    na.rm = TRUE),
+    proj_last = min(om$data_list$projyr, em$data_list$projyr))
 
   # - Adjust catch multiplier
   # Checked against the years catch is actually FILLED for, which is the

--- a/R/10-run_mse.R
+++ b/R/10-run_mse.R
@@ -192,8 +192,10 @@
            "period, or list two or more assessment years.", call. = FALSE)
     }
 
-    return(seq(from = om_endyr + assessment_period, to = max_yr,
-               by = assessment_period))
+    return(.mse_warn_short_schedule(
+      seq(from = om_endyr + assessment_period, to = max_yr,
+          by = assessment_period),
+      max_yr))
   }
 
   # * An explicit schedule ----
@@ -219,6 +221,37 @@
          call. = FALSE)
   }
 
+  .mse_warn_short_schedule(assess_yrs, max_yr)
+}
+
+# A schedule that stops short of the projection horizon leaves the trailing
+# years with no catch at all: run_mse() only ever fills catch up to the last
+# assessment, so those years keep the NA the projection rows were created with.
+#
+# mse_summary() then counts them anyway. `projyrs` there runs to the models'
+# own projyr, so the NA years sit in the denominator of P(Closed) but not its
+# numerator, in both halves of Catch IAV, and outside the na.rm mean that is
+# Average Catch. All three come out low, with nothing in the table saying which
+# years were summarised. A biennial cycle over an odd number of projection
+# years lands here every time -- 2027(2)2049 against a 2050 horizon.
+#
+# Warned rather than refused: a schedule that stops short is a legitimate
+# design, it just has to be summarised over the years it covers.
+.mse_warn_short_schedule <- function(assess_yrs, max_yr) {
+  last <- max(assess_yrs)
+  if (last < max_yr) {
+    unfished <- if (last + 1 == max_yr) {
+      as.character(max_yr)
+    } else {
+      paste0(last + 1, "-", max_yr)
+    }
+    warning("The last assessment is in ", last, " but the projection runs to ",
+            max_yr, ", so catch in ", unfished, " is never set. Those years ",
+            "carry NA, and mse_summary() understates Average Catch, Catch IAV ",
+            "and P(Closed) because it summarises over the whole projection. ",
+            "Either extend the schedule to ", max_yr, ", or set projyr to ",
+            last, " in both models.", call. = FALSE)
+  }
   assess_yrs
 }
 
@@ -265,9 +298,9 @@
     off <- catch_mult$Year[catch_mult$Year < proj_first |
                              catch_mult$Year > proj_last]
     if (length(off)) {
-      stop("`catch_mult$Year` must be a projection year (", proj_first, ":",
-           proj_last, "); got ", paste(sort(unique(off)), collapse = ", "), ".",
-           call. = FALSE)
+      stop("`catch_mult$Year` must be a year the assessment schedule covers (",
+           proj_first, ":", proj_last, "); got ",
+           paste(sort(unique(off)), collapse = ", "), ".", call. = FALSE)
     }
 
     key <- paste(catch_mult$Year, catch_mult$Species)
@@ -323,7 +356,7 @@
 #' @param rec_trend Linear increase or decrease in mean recruitment from \code{endyr} to \code{projyr}. This is the terminal multiplier \code{mean rec * (1 + (rec_trend/projection years) * 1:projection years)}. Can be of length 1 or of length nspp. If length 1, all species get the same trend.
 #' @param fut_sample future sampling effort relative to last year.  \code{ Log_sd * 1 / fut_sample} for index and \code{ Sample_size * fut_sample} for comps
 #' @param cap A cap on the catch in the projection. Can be a single number applied to all species (proportional to recommended catch) or vector of length \code{nspp} applied to each species. Default = NULL
-#' @param catch_mult A multiplier applied to the catch the control rule recommends. A single number or a vector of length \code{nspp} applies in every projection year; a \code{data.frame} with columns \code{Year}, \code{Species} and \code{mult} applies only in the year and species pairs it lists. Default = NULL
+#' @param catch_mult A multiplier applied to the catch the control rule recommends. A single number or a vector of length \code{nspp} applies in every projection year; a \code{data.frame} with columns \code{Year}, \code{Species} and \code{mult} applies only in the year and species pairs it lists, where \code{Year} is a year the assessment schedule covers. Default = NULL
 #' @param loopnum number of times to re-start optimization (where \code{loopnum=3} sometimes achieves a lower final gradient than \code{loopnum=1})
 #' @param file (Optional) Filename where each OM simulation with EMs will be saved. If NULL, no files are saved.
 #' @param dir (Optional) Directory where each OM simulation is saved
@@ -357,6 +390,14 @@
 #' from a period, and the two readings are a world apart, so it is refused
 #' rather than guessed at.
 #'
+#' Make the last assessment year reach the projection horizon. Catch is only
+#' ever filled up to the last assessment, so a schedule that stops short leaves
+#' the trailing years at `NA`, and `mse_summary()` summarises over the whole
+#' projection --- understating Average Catch, Catch IAV and P(Closed) with
+#' nothing in the table to say which years it covered. A biennial cycle over an
+#' odd number of projection years lands here every time, so this is warned
+#' about, for a period and a schedule alike.
+#'
 #' # Catch multiplier
 #'
 #' `catch_mult` multiplies the catch the estimation model's control rule
@@ -372,7 +413,10 @@
 #' ```
 #'
 #' `Species` is the species number, matching the catch data's own column, and
-#' any (year, species) pair the table omits is multiplied by 1.
+#' any (year, species) pair the table omits is multiplied by 1. `Year` must be
+#' a year the assessment schedule actually covers --- from the operating
+#' model's terminal year to the last assessment, which is where catch is
+#' filled, not the whole projection.
 #'
 #' Note that this reduces catch, not ABC. Where realized catch sits well below
 #' ABC -- GOA arrowtooth flounder, for one -- reducing ABC changes removals only
@@ -422,12 +466,6 @@ run_mse <- function(om, em, nsim = 10, start_sim = 1, assessment_period = 1, sam
       stop("cap is not length 1 or length nspp")
     }
   }
-
-  # - Adjust catch multiplier
-  catch_mult <- .mse_check_catch_mult(catch_mult,
-                                      nspp       = om$data_list$nspp,
-                                      proj_first = om$data_list$endyr + 1,
-                                      proj_last  = om$data_list$projyr)
 
   # na.rm: Proj_F_proportion is NA for fleets that never take catch (surveys),
   # which is a legitimate workbook value. Without it the sum is NA and the `if`
@@ -484,6 +522,17 @@ run_mse <- function(om, em, nsim = 10, start_sim = 1, assessment_period = 1, sam
     om_endyr = om$data_list$endyr,
     max_yr   = min(c(om$data_list$projyr, em$data_list$projyr, endyr),
                    na.rm = TRUE))
+
+  # - Adjust catch multiplier
+  # Checked against the years catch is actually FILLED for, which is the
+  # assessment schedule's own span -- not the projection horizon. The loop only
+  # writes catch up to the last assessment, so a multiplier named for a later
+  # year applies nowhere, which is the silent no-op this validation exists to
+  # catch.
+  catch_mult <- .mse_check_catch_mult(catch_mult,
+                                      nspp       = om$data_list$nspp,
+                                      proj_first = om$data_list$endyr + 1,
+                                      proj_last  = max(assess_yrs))
 
   # - Data sampling period
   if(length(sampling_period)==1){

--- a/R/10-run_mse.R
+++ b/R/10-run_mse.R
@@ -148,6 +148,165 @@
   fit
 }
 
+# Assessment years ------------------------------------------------------------
+#
+# `assessment_period` is read two ways. A single number is a fixed cycle: an
+# assessment every n years, counted from the operating model's terminal year to
+# the end of the MSE. A vector is the schedule itself -- the exact years an
+# assessment is completed. The two are different management questions: one
+# assessment missed inside an otherwise biennial cycle is a single episode of
+# stale advice, while a triennial period is a permanent policy, and the cost of
+# one is not the cost of the other.
+#
+# `max_yr` is the last year an assessment can be run in: the earlier of the two
+# models' projection horizons, and of `endyr` where the caller set one.
+.mse_assess_years <- function(assessment_period, om_endyr, max_yr) {
+  if (!is.numeric(assessment_period) || length(assessment_period) == 0 ||
+      anyNA(assessment_period)) {
+    stop("`assessment_period` must be a number of years, or a vector of the ",
+         "years an assessment is completed.", call. = FALSE)
+  }
+
+  fractional <- assessment_period[assessment_period != round(assessment_period)]
+  if (length(fractional)) {
+    stop("`assessment_period` must be whole years; got ",
+         paste(fractional, collapse = ", "), ".", call. = FALSE)
+  }
+
+  # * A period ----
+  if (length(assessment_period) == 1) {
+    if (assessment_period < 1) {
+      stop("`assessment_period` must be at least 1 year; got ",
+           assessment_period, ".", call. = FALSE)
+    }
+
+    # A schedule of one year cannot be told from a period, and the two readings
+    # of, say, 2029 are a world apart. Refused rather than guessed at -- and
+    # this is also where a period simply longer than the projection lands,
+    # which used to surface as seq()'s "wrong sign in 'by' argument".
+    if (om_endyr + assessment_period > max_yr) {
+      stop("A single `assessment_period` is the number of years BETWEEN ",
+           "assessments, not the year of one: ", om_endyr, " + ",
+           assessment_period, " is past the last year an assessment can be ",
+           "run in (", max_yr, "), so no assessment would run. Give the ",
+           "period, or list two or more assessment years.", call. = FALSE)
+    }
+
+    return(seq(from = om_endyr + assessment_period, to = max_yr,
+               by = assessment_period))
+  }
+
+  # * An explicit schedule ----
+  # round() rather than as.integer(): the years are already whole, and keeping
+  # them the same storage mode `seq()` returns keeps the two paths
+  # indistinguishable to everything downstream.
+  assess_yrs <- sort(unique(round(assessment_period)))
+
+  # Named and refused rather than dropped. A year outside the window cannot host
+  # an assessment, and quietly removing it would run a schedule the caller did
+  # not ask for and could not see anywhere in the result.
+  early <- assess_yrs[assess_yrs <= om_endyr]
+  if (length(early)) {
+    stop("`assessment_period` years must be after the operating model's ",
+         "terminal year (", om_endyr, "); got ",
+         paste(early, collapse = ", "), ".", call. = FALSE)
+  }
+
+  late <- assess_yrs[assess_yrs > max_yr]
+  if (length(late)) {
+    stop("`assessment_period` years must be within the projection horizon ",
+         "(through ", max_yr, "); got ", paste(late, collapse = ", "), ".",
+         call. = FALSE)
+  }
+
+  assess_yrs
+}
+
+# Catch multiplier ------------------------------------------------------------
+#
+# `catch_mult` scales the catch the estimation model's control rule recommends,
+# before the cap and before the exploitable-biomass limit. A single number or a
+# vector of length nspp applies in every projection year, which is a permanent
+# change in harvest policy. A data.frame of Year / Species / mult applies only
+# in the pairs it lists -- a buffer held for the years advice is stale, say --
+# and every pair it does not list is multiplied by 1.
+#
+# `Species` is the species number, the same code the catch data carries.
+# Validated up front so a mistyped year or species number is reported once at
+# the call, not silently ignored inside every simulation as a multiplier of 1.
+.mse_check_catch_mult <- function(catch_mult, nspp, proj_first, proj_last) {
+  if (is.null(catch_mult)) return(NULL)
+
+  # * Year- and species-indexed ----
+  if (is.data.frame(catch_mult)) {
+    absent <- setdiff(c("Year", "Species", "mult"), names(catch_mult))
+    if (length(absent)) {
+      stop("A `catch_mult` data.frame needs columns Year, Species and mult; ",
+           "missing ", paste(absent, collapse = ", "), ".", call. = FALSE)
+    }
+    if (nrow(catch_mult) == 0) {
+      stop("`catch_mult` has no rows. Pass NULL for no multiplier.",
+           call. = FALSE)
+    }
+    if (!is.numeric(catch_mult$mult) || anyNA(catch_mult$mult) ||
+        any(!is.finite(catch_mult$mult)) || any(catch_mult$mult < 0)) {
+      stop("`catch_mult$mult` must be finite and non-negative.", call. = FALSE)
+    }
+    if (!is.numeric(catch_mult$Species) || anyNA(catch_mult$Species) ||
+        any(!catch_mult$Species %in% seq_len(nspp))) {
+      stop("`catch_mult$Species` must be a species number in 1:", nspp, ".",
+           call. = FALSE)
+    }
+    if (!is.numeric(catch_mult$Year) || anyNA(catch_mult$Year) ||
+        any(catch_mult$Year != round(catch_mult$Year))) {
+      stop("`catch_mult$Year` must be a whole year.", call. = FALSE)
+    }
+
+    off <- catch_mult$Year[catch_mult$Year < proj_first |
+                             catch_mult$Year > proj_last]
+    if (length(off)) {
+      stop("`catch_mult$Year` must be a projection year (", proj_first, ":",
+           proj_last, "); got ", paste(sort(unique(off)), collapse = ", "), ".",
+           call. = FALSE)
+    }
+
+    key <- paste(catch_mult$Year, catch_mult$Species)
+    if (anyDuplicated(key)) {
+      stop("`catch_mult` gives more than one multiplier for the same year and ",
+           "species: ", paste(unique(key[duplicated(key)]), collapse = "; "),
+           ".", call. = FALSE)
+    }
+
+    return(catch_mult)
+  }
+
+  # * One multiplier per species, every year ----
+  if (!is.numeric(catch_mult) || anyNA(catch_mult) ||
+      any(!is.finite(catch_mult)) || any(catch_mult < 0)) {
+    stop("`catch_mult` must be finite and non-negative.", call. = FALSE)
+  }
+  if (length(catch_mult) == 1) {
+    catch_mult <- rep(catch_mult, nspp)
+  }
+  if (length(catch_mult) != nspp) {
+    stop("catch_mult is not length 1 or length nspp")
+  }
+  catch_mult
+}
+
+# Apply the multiplier to the catch rows filled for this assessment interval.
+# `year` and `species` are those rows' own Year and Species columns.
+.mse_apply_catch_mult <- function(catch, year, species, catch_mult) {
+  if (is.data.frame(catch_mult)) {
+    idx <- match(paste(year, species),
+                 paste(catch_mult$Year, catch_mult$Species))
+    mult <- catch_mult$mult[idx]
+    mult[is.na(idx)] <- 1   # a pair the caller did not list is left alone
+    return(catch * mult)
+  }
+  catch * catch_mult[species]
+}
+
 #' Run a management strategy evaluation
 #'
 #' @description Runs a forward-projecting management strategy evaluation (MSE). Projected selectivity, catchability, foraging days, and weight-at-age are held at the operating model's terminal hindcast year. Survey SD is set to the average over the historical time series, and composition sample size is held at the last year. There is no implementation error and no observation error on catch.
@@ -156,7 +315,7 @@
 #' @param em CEATTLE model object exported from \code{Rceattle}
 #' @param nsim Number of simulations to run (default 10)
 #' @param start_sim First simulation number to start at. Useful if the code stops at specific seed/sim (default = 1).
-#' @param assessment_period Period of years that each assessment is taken
+#' @param assessment_period Assessment schedule. A single number is the period in years between assessments, counted from the operating model's terminal year. A vector is the explicit set of years an assessment is completed. Default = 1.
 #' @param sampling_period Period of years data sampling is conducted. Single value or vector the same length as the number of fleets.
 #' @param simulate_data Include simulated random error proportional to that estimated/provided for the data from the OM.
 #' @param regenerate_past Refits the EM to historical/conditioning data prior to the MSE, where the data are generated from the OM with \code{simulate_data = TRUE} or without \code{simulate_data = FALSE} sampling error.
@@ -164,7 +323,7 @@
 #' @param rec_trend Linear increase or decrease in mean recruitment from \code{endyr} to \code{projyr}. This is the terminal multiplier \code{mean rec * (1 + (rec_trend/projection years) * 1:projection years)}. Can be of length 1 or of length nspp. If length 1, all species get the same trend.
 #' @param fut_sample future sampling effort relative to last year.  \code{ Log_sd * 1 / fut_sample} for index and \code{ Sample_size * fut_sample} for comps
 #' @param cap A cap on the catch in the projection. Can be a single number applied to all species (proportional to recommended catch) or vector of length \code{nspp} applied to each species. Default = NULL
-#' @param catch_mult A multiplier for the catch in the projection. Can be a single number or vector of length nspp. Default = NULL
+#' @param catch_mult A multiplier applied to the catch the control rule recommends. A single number or a vector of length \code{nspp} applies in every projection year; a \code{data.frame} with columns \code{Year}, \code{Species} and \code{mult} applies only in the year and species pairs it lists. Default = NULL
 #' @param loopnum number of times to re-start optimization (where \code{loopnum=3} sometimes achieves a lower final gradient than \code{loopnum=1})
 #' @param file (Optional) Filename where each OM simulation with EMs will be saved. If NULL, no files are saved.
 #' @param dir (Optional) Directory where each OM simulation is saved
@@ -176,6 +335,51 @@
 #'   \code{NULL} picks \code{parallel::detectCores() - 6}, capped at 2 when
 #'   running under \code{R CMD check} (which sets
 #'   \code{_R_CHECK_LIMIT_CORES_}). Set to 1 to force sequential execution.
+#'
+#' @details
+#' # Assessment schedule
+#'
+#' A single `assessment_period` is a fixed cycle. A vector is the schedule
+#' itself, for a design whose years are not evenly spaced -- one assessment
+#' missed inside an otherwise biennial cycle, for instance:
+#'
+#' ```
+#' biennial <- seq(om$data_list$endyr + 2, om$data_list$projyr, by = 2)
+#' run_mse(om, em, assessment_period = setdiff(biennial, 2031))
+#' ```
+#'
+#' Every year must be after the operating model's terminal year and within the
+#' projection horizon; a year outside that window is an error rather than being
+#' dropped. One missed assessment and a permanently longer cycle are different
+#' questions, and the second does not answer the first.
+#'
+#' A schedule must name two or more years. One year on its own cannot be told
+#' from a period, and the two readings are a world apart, so it is refused
+#' rather than guessed at.
+#'
+#' # Catch multiplier
+#'
+#' `catch_mult` multiplies the catch the estimation model's control rule
+#' recommends, before `cap` and before the exploitable-biomass limit. Given as
+#' a `data.frame` it applies only in the years and species it lists, which is
+#' how a buffer held for the years advice is stale is expressed:
+#'
+#' ```
+#' buffer <- expand.grid(Year = 2031:2032, Species = seq_len(om$data_list$nspp))
+#' buffer$mult <- 0.90
+#' run_mse(om, em, assessment_period = setdiff(biennial, 2031),
+#'         catch_mult = buffer)
+#' ```
+#'
+#' `Species` is the species number, matching the catch data's own column, and
+#' any (year, species) pair the table omits is multiplied by 1.
+#'
+#' Note that this reduces catch, not ABC. Where realized catch sits well below
+#' ABC -- GOA arrowtooth flounder, for one -- reducing ABC changes removals only
+#' to the extent the fishery attains it, while reducing catch changes them in
+#' full. Either scale the multiplier by recent attainment,
+#' `1 - (1 - mult) * attainment`, or report the unscaled result as an upper
+#' bound on the effect of the reduction.
 #'
 #' @return A list of operating models (differ by simulated recruitment determined by \code{nsim}) and estimation models fit to each operating model (differ by terminal year).
 #' @examples
@@ -219,15 +423,11 @@ run_mse <- function(om, em, nsim = 10, start_sim = 1, assessment_period = 1, sam
     }
   }
 
-  if(!is.null(catch_mult)){
-    if(length(catch_mult) == 1){
-      catch_mult = rep(catch_mult, om$data_list$nspp)
-    }
-
-    if(length(catch_mult) != om$data_list$nspp){
-      stop("catch_mult is not length 1 or length nspp")
-    }
-  }
+  # - Adjust catch multiplier
+  catch_mult <- .mse_check_catch_mult(catch_mult,
+                                      nspp       = om$data_list$nspp,
+                                      proj_first = om$data_list$endyr + 1,
+                                      proj_last  = om$data_list$projyr)
 
   # na.rm: Proj_F_proportion is NA for fleets that never take catch (surveys),
   # which is a legitimate workbook value. Without it the sum is NA and the `if`
@@ -278,8 +478,12 @@ run_mse <- function(om, em, nsim = 10, start_sim = 1, assessment_period = 1, sam
     n_sel_bins_em <- max(em$data_list$fleet_control$N_sel_bins, na.rm = TRUE)
   }
 
-  # - Assessment period
-  assess_yrs <- seq(from = om$data_list$endyr + assessment_period, to =  min(c(om$data_list$projyr, em$data_list$projyr, endyr), na.rm = TRUE),  by = assessment_period)
+  # - Assessment period, or an explicit schedule of assessment years
+  assess_yrs <- .mse_assess_years(
+    assessment_period,
+    om_endyr = om$data_list$endyr,
+    max_yr   = min(c(om$data_list$projyr, em$data_list$projyr, endyr),
+                   na.rm = TRUE))
 
   # - Data sampling period
   if(length(sampling_period)==1){
@@ -544,7 +748,11 @@ run_mse <- function(om, em, nsim = 10, start_sim = 1, assessment_period = 1, sam
 
       # * Catch multiplier ----
       if(!is.null(catch_mult)){
-        new_catch_data$Catch[dat_fill_ind] <- new_catch_data$Catch[dat_fill_ind] * catch_mult[new_catch_data$Species[dat_fill_ind]]
+        new_catch_data$Catch[dat_fill_ind] <- .mse_apply_catch_mult(
+          catch      = new_catch_data$Catch[dat_fill_ind],
+          year       = new_catch_data$Year[dat_fill_ind],
+          species    = new_catch_data$Species[dat_fill_ind],
+          catch_mult = catch_mult)
       }
 
       # * Apply cap ----

--- a/man/run_mse.Rd
+++ b/man/run_mse.Rd
@@ -37,7 +37,7 @@ run_mse(
 
 \item{start_sim}{First simulation number to start at. Useful if the code stops at specific seed/sim (default = 1).}
 
-\item{assessment_period}{Period of years that each assessment is taken}
+\item{assessment_period}{Assessment schedule. A single number is the period in years between assessments, counted from the operating model's terminal year. A vector is the explicit set of years an assessment is completed. Default = 1.}
 
 \item{sampling_period}{Period of years data sampling is conducted. Single value or vector the same length as the number of fleets.}
 
@@ -53,7 +53,7 @@ run_mse(
 
 \item{cap}{A cap on the catch in the projection. Can be a single number applied to all species (proportional to recommended catch) or vector of length \code{nspp} applied to each species. Default = NULL}
 
-\item{catch_mult}{A multiplier for the catch in the projection. Can be a single number or vector of length nspp. Default = NULL}
+\item{catch_mult}{A multiplier applied to the catch the control rule recommends. A single number or a vector of length \code{nspp} applies in every projection year; a \code{data.frame} with columns \code{Year}, \code{Species} and \code{mult} applies only in the year and species pairs it lists. Default = NULL}
 
 \item{seed}{seed for the simulation}
 
@@ -80,6 +80,48 @@ A list of operating models (differ by simulated recruitment determined by \code{
 \description{
 Runs a forward-projecting management strategy evaluation (MSE). Projected selectivity, catchability, foraging days, and weight-at-age are held at the operating model's terminal hindcast year. Survey SD is set to the average over the historical time series, and composition sample size is held at the last year. There is no implementation error and no observation error on catch.
 }
+\section{Assessment schedule}{
+A single \code{assessment_period} is a fixed cycle. A vector is the schedule
+itself, for a design whose years are not evenly spaced -- one assessment
+missed inside an otherwise biennial cycle, for instance:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{biennial <- seq(om$data_list$endyr + 2, om$data_list$projyr, by = 2)
+run_mse(om, em, assessment_period = setdiff(biennial, 2031))
+}\if{html}{\out{</div>}}
+
+Every year must be after the operating model's terminal year and within the
+projection horizon; a year outside that window is an error rather than being
+dropped. One missed assessment and a permanently longer cycle are different
+questions, and the second does not answer the first.
+
+A schedule must name two or more years. One year on its own cannot be told
+from a period, and the two readings are a world apart, so it is refused
+rather than guessed at.
+}
+
+\section{Catch multiplier}{
+\code{catch_mult} multiplies the catch the estimation model's control rule
+recommends, before \code{cap} and before the exploitable-biomass limit. Given as
+a \code{data.frame} it applies only in the years and species it lists, which is
+how a buffer held for the years advice is stale is expressed:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{buffer <- expand.grid(Year = 2031:2032, Species = seq_len(om$data_list$nspp))
+buffer$mult <- 0.90
+run_mse(om, em, assessment_period = setdiff(biennial, 2031),
+        catch_mult = buffer)
+}\if{html}{\out{</div>}}
+
+\code{Species} is the species number, matching the catch data's own column, and
+any (year, species) pair the table omits is multiplied by 1.
+
+Note that this reduces catch, not ABC. Where realized catch sits well below
+ABC -- GOA arrowtooth flounder, for one -- reducing ABC changes removals only
+to the extent the fishery attains it, while reducing catch changes them in
+full. Either scale the multiplier by recent attainment,
+\code{1 - (1 - mult) * attainment}, or report the unscaled result as an upper
+bound on the effect of the reduction.
+}
+
 \examples{
 \dontrun{
 data(BS2017SS)

--- a/man/run_mse.Rd
+++ b/man/run_mse.Rd
@@ -98,6 +98,18 @@ A schedule must name two or more years. One year on its own cannot be told
 from a period, and the two readings are a world apart, so it is refused
 rather than guessed at.
 
+Two schedules run on the same \code{seed} are \strong{not} on common random numbers.
+Between assessments the operating model's projection horizon is shortened to
+the next assessment year, so \code{sim_mod()} draws over a different number of
+projection rows depending on the schedule, and the observation draws diverge
+from the first assessment onward. On a three-year BS2017SS fixture, dropping
+one assessment moved catch in a year whose advice was identical by
+construction by 2.1\%. A paired comparison of two schedules therefore carries
+an observation-error difference alongside the schedule effect; treat the
+difference as containing Monte Carlo noise, and use enough replicates to
+separate the two rather than relying on variance reduction that is not
+there.
+
 Make the last assessment year reach the projection horizon. Catch is only
 ever filled up to the last assessment, so a schedule that stops short leaves
 the trailing years at \code{NA}, and \code{mse_summary()} summarises over the whole
@@ -111,9 +123,14 @@ about, for a period and a schedule alike.
 \code{catch_mult} multiplies the catch the estimation model's control rule
 recommends, before \code{cap} and before the exploitable-biomass limit. Given as
 a \code{data.frame} it applies only in the years and species it lists, which is
-how a buffer held for the years advice is stale is expressed:
+how a buffer held for the years advice is stale is expressed.
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{buffer <- expand.grid(Year = 2031:2032, Species = seq_len(om$data_list$nspp))
+Mind which years those are. The assessment in year \code{Y} sets catch for \code{Y+1}
+onward, so a missed assessment in 2031 leaves \strong{2032 and 2033} on 2029's
+advice --- 2031 itself is set by the 2029 assessment either way, and cutting
+it changes a year the missed assessment never touched:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{buffer <- expand.grid(Year = 2032:2033, Species = seq_len(om$data_list$nspp))
 buffer$mult <- 0.90
 run_mse(om, em, assessment_period = setdiff(biennial, 2031),
         catch_mult = buffer)

--- a/man/run_mse.Rd
+++ b/man/run_mse.Rd
@@ -53,7 +53,7 @@ run_mse(
 
 \item{cap}{A cap on the catch in the projection. Can be a single number applied to all species (proportional to recommended catch) or vector of length \code{nspp} applied to each species. Default = NULL}
 
-\item{catch_mult}{A multiplier applied to the catch the control rule recommends. A single number or a vector of length \code{nspp} applies in every projection year; a \code{data.frame} with columns \code{Year}, \code{Species} and \code{mult} applies only in the year and species pairs it lists. Default = NULL}
+\item{catch_mult}{A multiplier applied to the catch the control rule recommends. A single number or a vector of length \code{nspp} applies in every projection year; a \code{data.frame} with columns \code{Year}, \code{Species} and \code{mult} applies only in the year and species pairs it lists, where \code{Year} is a year the assessment schedule covers. Default = NULL}
 
 \item{seed}{seed for the simulation}
 
@@ -97,6 +97,14 @@ questions, and the second does not answer the first.
 A schedule must name two or more years. One year on its own cannot be told
 from a period, and the two readings are a world apart, so it is refused
 rather than guessed at.
+
+Make the last assessment year reach the projection horizon. Catch is only
+ever filled up to the last assessment, so a schedule that stops short leaves
+the trailing years at \code{NA}, and \code{mse_summary()} summarises over the whole
+projection --- understating Average Catch, Catch IAV and P(Closed) with
+nothing in the table to say which years it covered. A biennial cycle over an
+odd number of projection years lands here every time, so this is warned
+about, for a period and a schedule alike.
 }
 
 \section{Catch multiplier}{
@@ -112,7 +120,10 @@ run_mse(om, em, assessment_period = setdiff(biennial, 2031),
 }\if{html}{\out{</div>}}
 
 \code{Species} is the species number, matching the catch data's own column, and
-any (year, species) pair the table omits is multiplied by 1.
+any (year, species) pair the table omits is multiplied by 1. \code{Year} must be
+a year the assessment schedule actually covers --- from the operating
+model's terminal year to the last assessment, which is where catch is
+filled, not the whole projection.
 
 Note that this reduces catch, not ABC. Where realized catch sits well below
 ABC -- GOA arrowtooth flounder, for one -- reducing ABC changes removals only

--- a/tests/testthat/test-mse-schedule-and-catch-mult.R
+++ b/tests/testthat/test-mse-schedule-and-catch-mult.R
@@ -21,8 +21,30 @@ test_that("a scalar assessment_period is the regular grid it always was", {
                2021:2025)
 
   # The grid stops at max_yr rather than stepping past it.
-  expect_equal(.mse_assess_years(4, om_endyr = 2020, max_yr = 2030),
+  expect_equal(suppressWarnings(.mse_assess_years(4, om_endyr = 2020,
+                                                  max_yr = 2030)),
                c(2024, 2028))
+})
+
+
+test_that("a schedule that stops short of the horizon warns", {
+  # run_mse() fills catch only up to the last assessment, and mse_summary()
+  # summarises over the models' whole projection -- so the trailing NA years
+  # sit in the denominator of P(Closed) and Catch IAV but contribute nothing.
+  # A biennial cycle over an odd number of projection years lands here every
+  # time: 2022(2)2028 against a 2029 horizon, or 2027(2)2049 against 2050.
+  expect_warning(.mse_assess_years(2, om_endyr = 2020, max_yr = 2029),
+                 "catch in 2029 is never set")
+  expect_warning(.mse_assess_years(4, om_endyr = 2020, max_yr = 2030),
+                 "catch in 2029-2030 is never set")
+  expect_warning(.mse_assess_years(c(2022, 2024), om_endyr = 2020,
+                                   max_yr = 2030),
+                 "understates Average Catch")
+
+  # Reaching the horizon exactly is the quiet case, on both paths.
+  expect_silent(.mse_assess_years(2, om_endyr = 2020, max_yr = 2030))
+  expect_silent(.mse_assess_years(c(2022, 2030), om_endyr = 2020,
+                                  max_yr = 2030))
 })
 
 
@@ -35,13 +57,14 @@ test_that("a vector assessment_period is the schedule itself", {
 
   # Sorted and de-duplicated, so the order the caller happened to build them in
   # does not change which year the loop treats as terminal.
-  expect_equal(.mse_assess_years(c(2028, 2022, 2028, 2024),
-                                 om_endyr = 2020, max_yr = 2030),
+  expect_equal(suppressWarnings(.mse_assess_years(c(2028, 2022, 2028, 2024),
+                                                  om_endyr = 2020,
+                                                  max_yr = 2030)),
                c(2022, 2024, 2028))
 
   # The skipped schedule is NOT the triennial grid it superficially resembles.
   expect_false(identical(.mse_assess_years(skipped, 2020, 2030),
-                         .mse_assess_years(3, 2020, 2030)))
+                         suppressWarnings(.mse_assess_years(3, 2020, 2030))))
 })
 
 
@@ -151,11 +174,17 @@ test_that("catch_mult is validated at the call, in either form", {
                                      nspp = 3, 2021, 2030),
                "missing Species")
 
-  # A year outside the projection could never be applied, so a typo would
-  # otherwise read as "no reduction" in a run that looks like it worked.
+  # A year the schedule never reaches could never be applied, so a typo would
+  # otherwise read as "no reduction" in a run that looks like it worked. The
+  # upper bound is the LAST ASSESSMENT year, not projyr: run_mse() fills catch
+  # only up to the last assessment, so a multiplier named for a later year
+  # applies nowhere even though it is inside the projection.
   expect_error(.mse_check_catch_mult(data.frame(Year = 2019, Species = 1, mult = 0.9),
                                      nspp = 3, 2021, 2030),
-               "must be a projection year")
+               "a year the assessment schedule covers")
+  expect_error(.mse_check_catch_mult(data.frame(Year = 2029, Species = 1, mult = 0.9),
+                                     nspp = 3, 2021, 2028),
+               "2021:2028")
 
   expect_error(.mse_check_catch_mult(data.frame(Year = 2022, Species = 4, mult = 0.9),
                                      nspp = 3, 2021, 2030),

--- a/tests/testthat/test-mse-schedule-and-catch-mult.R
+++ b/tests/testthat/test-mse-schedule-and-catch-mult.R
@@ -1,0 +1,179 @@
+# Two ways of specifying an MSE that run_mse() reads off its arguments before
+# any model is fitted: the years an assessment is completed, and the multiplier
+# applied to the catch the control rule recommends.
+#
+# Provenance: both exist for a design in which the schedule is IRREGULAR -- one
+# assessment missed inside an otherwise biennial cycle, with a precautionary
+# reduction held only for the years advice is stale. A scalar period cannot
+# express the first (it is a permanent policy, a different question) and a
+# per-species multiplier cannot express the second (it applies in every
+# projection year, which is a permanent harvest cut).
+#
+# Tested against the two internal helpers rather than a run_mse() call: these
+# are bookkeeping rules, and fitting an operating and an estimation model to
+# exercise them would take minutes.
+
+test_that("a scalar assessment_period is the regular grid it always was", {
+  # endyr 2020, projyr 2030: biennial assessments from 2022.
+  expect_equal(.mse_assess_years(2, om_endyr = 2020, max_yr = 2030),
+               seq(2022, 2030, by = 2))
+  expect_equal(.mse_assess_years(1, om_endyr = 2020, max_yr = 2025),
+               2021:2025)
+
+  # The grid stops at max_yr rather than stepping past it.
+  expect_equal(.mse_assess_years(4, om_endyr = 2020, max_yr = 2030),
+               c(2024, 2028))
+})
+
+
+test_that("a vector assessment_period is the schedule itself", {
+  biennial <- seq(2022, 2030, by = 2)
+  skipped  <- setdiff(biennial, 2026)
+
+  expect_equal(.mse_assess_years(skipped, om_endyr = 2020, max_yr = 2030),
+               c(2022, 2024, 2028, 2030))
+
+  # Sorted and de-duplicated, so the order the caller happened to build them in
+  # does not change which year the loop treats as terminal.
+  expect_equal(.mse_assess_years(c(2028, 2022, 2028, 2024),
+                                 om_endyr = 2020, max_yr = 2030),
+               c(2022, 2024, 2028))
+
+  # The skipped schedule is NOT the triennial grid it superficially resembles.
+  expect_false(identical(.mse_assess_years(skipped, 2020, 2030),
+                         .mse_assess_years(3, 2020, 2030)))
+})
+
+
+test_that("assessment years outside the projection window are refused, not dropped", {
+  # Before or at the operating model's terminal year: there is no projection
+  # year for the assessment to advance the model to.
+  expect_error(.mse_assess_years(c(2019, 2022), om_endyr = 2020, max_yr = 2030),
+               "after the operating model's terminal year")
+  expect_error(.mse_assess_years(c(2020, 2022), om_endyr = 2020, max_yr = 2030),
+               "2020")
+
+  # Past the horizon. Silently dropping it would run a shorter schedule than
+  # the caller asked for, with nothing in the result to say so.
+  expect_error(.mse_assess_years(c(2022, 2032), om_endyr = 2020, max_yr = 2030),
+               "within the projection horizon")
+
+  # A fractional year would set the operating model's endyr to a fraction, and
+  # nothing downstream indexes on one.
+  expect_error(.mse_assess_years(2.5, om_endyr = 2020, max_yr = 2030),
+               "whole years")
+  expect_error(.mse_assess_years(0, om_endyr = 2020, max_yr = 2030),
+               "at least 1 year")
+  expect_error(.mse_assess_years(c(2022, NA), om_endyr = 2020, max_yr = 2030),
+               "must be a number of years")
+})
+
+
+test_that("one year on its own is refused rather than read as a period", {
+  # The overload's only blind spot: length 1 is a period, so a schedule naming
+  # a single assessment year cannot be told from one. Read as a period, 2025
+  # would start the grid in 4045 and seq() would fail on the sign of `by`;
+  # the point of the guard is that the message says which reading was taken.
+  expect_error(.mse_assess_years(2025, om_endyr = 2020, max_yr = 2030),
+               "number of years BETWEEN assessments")
+
+  # The same guard catches a period simply longer than the projection, which
+  # is the case that used to reach seq() and report on its `by` argument.
+  expect_error(.mse_assess_years(20, om_endyr = 2020, max_yr = 2030),
+               "no assessment would run")
+
+  # A period that just reaches the last year is fine.
+  expect_equal(.mse_assess_years(10, om_endyr = 2020, max_yr = 2030), 2030)
+})
+
+
+test_that("a vector catch_mult still applies to every year of every species", {
+  # Three species, two projection years, one fleet each.
+  catch   <- c(100, 200, 300, 100, 200, 300)
+  year    <- rep(c(2021, 2022), each = 3)
+  species <- rep(1:3, times = 2)
+
+  out <- .mse_apply_catch_mult(catch, year, species, c(0.9, 1, 0.5))
+  expect_equal(out, c(90, 200, 150, 90, 200, 150))
+})
+
+
+test_that("a data.frame catch_mult applies only in the years and species it lists", {
+  catch   <- c(100, 200, 300, 100, 200, 300)
+  year    <- rep(c(2021, 2022), each = 3)
+  species <- rep(1:3, times = 2)
+
+  # A 10% reduction in 2022 only, and on species 1 and 3 only.
+  cm <- data.frame(Year = c(2022, 2022), Species = c(1, 3), mult = 0.9)
+
+  out <- .mse_apply_catch_mult(catch, year, species, cm)
+
+  # 2021 is untouched -- this is the whole point of the year-indexed form.
+  expect_equal(out[1:3], c(100, 200, 300))
+  # 2022 species 2 is untouched too: a pair the table omits is multiplied by 1.
+  expect_equal(out[4:6], c(90, 200, 270))
+
+  # And it is not the same as the equivalent per-species vector, which would
+  # have cut 2021 as well.
+  expect_false(isTRUE(all.equal(
+    out, .mse_apply_catch_mult(catch, year, species, c(0.9, 1, 0.9)))))
+})
+
+
+test_that("a data.frame catch_mult with no matching row leaves catch unchanged", {
+  catch   <- c(100, 200)
+  year    <- c(2021, 2021)
+  species <- c(1, 2)
+
+  cm <- data.frame(Year = 2022, Species = 1, mult = 0.5)
+  expect_equal(.mse_apply_catch_mult(catch, year, species, cm), catch)
+})
+
+
+test_that("catch_mult is validated at the call, in either form", {
+  # Vector form: recycled from length 1, checked against nspp, unchanged
+  # message so an existing script's error still reads the same.
+  expect_equal(.mse_check_catch_mult(0.8, nspp = 3, 2021, 2030),
+               rep(0.8, 3))
+  expect_error(.mse_check_catch_mult(c(0.8, 0.9), nspp = 3, 2021, 2030),
+               "not length 1 or length nspp")
+  expect_error(.mse_check_catch_mult(-1, nspp = 3, 2021, 2030),
+               "finite and non-negative")
+  expect_null(.mse_check_catch_mult(NULL, nspp = 3, 2021, 2030))
+
+  # A 3-column data.frame has length 3. Without a data.frame branch ahead of
+  # the length test it would pass silently at nspp = 3 and then be indexed as
+  # a vector -- the reason the check is on is.data.frame() first.
+  cm <- data.frame(Year = 2022, Species = 1, mult = 0.9)
+  expect_identical(.mse_check_catch_mult(cm, nspp = 3, 2021, 2030), cm)
+
+  expect_error(.mse_check_catch_mult(data.frame(Year = 2022, mult = 0.9),
+                                     nspp = 3, 2021, 2030),
+               "missing Species")
+
+  # A year outside the projection could never be applied, so a typo would
+  # otherwise read as "no reduction" in a run that looks like it worked.
+  expect_error(.mse_check_catch_mult(data.frame(Year = 2019, Species = 1, mult = 0.9),
+                                     nspp = 3, 2021, 2030),
+               "must be a projection year")
+
+  expect_error(.mse_check_catch_mult(data.frame(Year = 2022, Species = 4, mult = 0.9),
+                                     nspp = 3, 2021, 2030),
+               "species number in 1:3")
+
+  # match() takes the first of a duplicated key, so the second row would be
+  # discarded without a word.
+  expect_error(.mse_check_catch_mult(
+    data.frame(Year = c(2022, 2022), Species = c(1, 1), mult = c(0.9, 0.5)),
+    nspp = 3, 2021, 2030),
+    "more than one multiplier")
+
+  expect_error(.mse_check_catch_mult(data.frame(Year = 2022, Species = 1, mult = NA),
+                                     nspp = 3, 2021, 2030),
+               "finite and non-negative")
+
+  expect_error(.mse_check_catch_mult(
+    data.frame(Year = numeric(0), Species = numeric(0), mult = numeric(0)),
+    nspp = 3, 2021, 2030),
+    "no rows")
+})

--- a/tests/testthat/test-mse-schedule-and-catch-mult.R
+++ b/tests/testthat/test-mse-schedule-and-catch-mult.R
@@ -48,6 +48,31 @@ test_that("a schedule that stops short of the horizon warns", {
 })
 
 
+test_that("the short-schedule test is against projyr, not run_mse(endyr)", {
+  # `endyr` caps the last year an assessment may run in, but mse_summary()
+  # reads the MODELS' projyr and takes no notice of it. So ending the MSE early
+  # leaves every remaining projection year unfished -- the same understatement,
+  # over more years -- and testing the schedule against `endyr` would call that
+  # case complete.
+  expect_warning(.mse_assess_years(2, om_endyr = 2020, max_yr = 2030,
+                                   proj_last = 2050),
+                 "catch in 2031-2050 is never set")
+  expect_warning(.mse_assess_years(c(2022, 2030), om_endyr = 2020,
+                                   max_yr = 2030, proj_last = 2050),
+                 "models project to 2050")
+
+  # The remedy named has to be one the caller can act on, so it points at
+  # projyr rather than at extending a schedule `endyr` has already capped.
+  expect_warning(.mse_assess_years(2, om_endyr = 2020, max_yr = 2030,
+                                   proj_last = 2050),
+                 "set projyr to 2030 in both models")
+
+  # proj_last defaults to max_yr, so a caller that passes neither is unchanged.
+  expect_silent(.mse_assess_years(2, om_endyr = 2020, max_yr = 2030,
+                                  proj_last = 2030))
+})
+
+
 test_that("a vector assessment_period is the schedule itself", {
   biennial <- seq(2022, 2030, by = 2)
   skipped  <- setdiff(biennial, 2026)

--- a/tools/verify/verify-mse-schedule.R
+++ b/tools/verify/verify-mse-schedule.R
@@ -118,12 +118,33 @@ results["skip_differs"] <- report(
   "skipping an assessment changes the trajectory",
   !isTRUE(all.equal(om_catch(mse_skip)$Catch, c_period$Catch)))
 
-# It must also not be the triennial period it superficially resembles: a period
+# It must also not be the biennial period it superficially resembles: a period
 # of 2 from 2017 is c(2019), a different schedule over a different horizon.
 results["skip_not_period"] <- report(
   "a skipped schedule is not the equivalent period",
   !identical(.mse_assess_years(c(2018, 2020), ENDYR, 2020),
-             .mse_assess_years(2, ENDYR, 2020)))
+             suppressWarnings(.mse_assess_years(2, ENDYR, 2020))))
+
+# The trailing years of a schedule that stops short carry NA catch, which is
+# what the short-schedule warning exists to report. Asserted against the run
+# rather than the helper, because it is a property of the loop's fill window.
+mse_short <- run(assessment_period = c(2018, 2019))
+short_cd  <- mse_short$Sim_1$OM$data_list$catch_data
+results["short_schedule_na"] <- report(
+  "a schedule stopping short leaves the trailing years' catch NA",
+  all(is.na(short_cd$Catch[short_cd$Year == 2020])) &&
+    !any(is.na(short_cd$Catch[short_cd$Year %in% 2018:2019])))
+
+warned <- character(0)
+withCallingHandlers(
+  .mse_assess_years(c(2018, 2019), ENDYR, 2020),
+  warning = function(w) {
+    warned <<- c(warned, conditionMessage(w))
+    invokeRestart("muffleWarning")
+  })
+results["short_schedule_warns"] <- report(
+  "and the short schedule is warned about",
+  any(grepl("catch in 2020 is never set", warned)))
 
 # --- 3. A year-indexed catch multiplier moves only the years it names ------
 buffer <- expand.grid(Year = 2020, Species = seq_len(NSPP))

--- a/tools/verify/verify-mse-schedule.R
+++ b/tools/verify/verify-mse-schedule.R
@@ -114,9 +114,45 @@ results["skip"] <- report(
     mse_skip$Sim_1$OM$data_list$endyr == 2020)
 
 # It must not be the same trajectory as assessing in every year.
+c_skip <- om_catch(mse_skip)
 results["skip_differs"] <- report(
   "skipping an assessment changes the trajectory",
-  !isTRUE(all.equal(om_catch(mse_skip)$Catch, c_period$Catch)))
+  !isTRUE(all.equal(c_skip$Catch, c_period$Catch)))
+
+# WHICH years the gap moves. By the advice mapping alone it should be 2020 and
+# 2020 only: the assessment in year Y sets catch for Y+1 onward, so dropping
+# the 2019 assessment leaves 2020 on 2018's advice, while 2019 is set by the
+# 2018 assessment in both schedules.
+#
+# It is not what happens. 2018 is identical, but 2019 moves as well -- 2880119
+# against 2941211 on this fixture, 2.1% -- on advice that is identical by
+# construction. The cause is the operating model's horizon shortening: at each
+# assessment the OM is trimmed to the NEXT assessment year, so sim_mod() draws
+# over a different number of projection rows depending on the schedule, and the
+# observation draws diverge from the first assessment onward. Two scenarios
+# differing only in their schedule are therefore NOT on common random numbers,
+# and a paired comparison between them carries an observation-error difference
+# it did not ask for.
+#
+# Pinned as it behaves today. If the draw is ever made independent of the
+# schedule, this check fails and points at the reason.
+i18 <- c_period$Year == 2018
+i19 <- c_period$Year == 2019
+i20 <- c_period$Year == 2020
+results["gap_year_2018_clean"] <- report(
+  "the year before the gap is bit-identical",
+  isTRUE(all.equal(c_skip$Catch[i18], c_period$Catch[i18], tolerance = 0)))
+
+results["gap_year_advice"] <- report(
+  "the year the missed assessment would have set moves",
+  !isTRUE(all.equal(c_skip$Catch[i20], c_period$Catch[i20])))
+
+results["gap_crn_broken"] <- report(
+  "KNOWN: a same-advice year moves too (draws are schedule-dependent)",
+  !isTRUE(all.equal(c_skip$Catch[i19], c_period$Catch[i19])),
+  paste0("2019 ratio = ",
+         format(sum(c_skip$Catch[i19]) / sum(c_period$Catch[i19]),
+                digits = 4)))
 
 # It must also not be the biennial period it superficially resembles: a period
 # of 2 from 2017 is c(2019), a different schedule over a different horizon.

--- a/tools/verify/verify-mse-schedule.R
+++ b/tools/verify/verify-mse-schedule.R
@@ -1,0 +1,174 @@
+# tools/verify/verify-mse-schedule.R
+# End-to-end net for the two run_mse() arguments that describe an irregular
+# assessment design: an explicit vector of assessment years, and a catch
+# multiplier indexed by year and species.
+#
+# test-mse-schedule-and-catch-mult.R covers the two helpers in isolation. What
+# it cannot show is that the values reach the loop unchanged -- that a schedule
+# supplied as years produces the SAME trajectory as the equivalent period, and
+# that a year-indexed multiplier moves catch in the years it names and in no
+# others. Both need a real closed loop, so they live here rather than in the
+# suite.
+#
+# Fixture: BS2017SS truncated to projyr 2020, the verify-mse-repro.R recipe.
+# endyr is 2017, so assessment_period = 1 is exactly c(2018, 2019, 2020) and
+# the two forms must agree to the last digit. Three projection years is the
+# shortest horizon that leaves room to skip an assessment and still have one on
+# either side of the gap.
+#
+# Determinism: cores = 1 and each sim self-seeds from seed + sim.
+#
+# Usage:
+#   export PATH=/usr/bin:$PATH
+#   NOT_CRAN=true Rscript tools/verify/verify-mse-schedule.R
+
+suppressMessages(pkgload::load_all(".", quiet = TRUE))
+
+# Proj_F_proportion must sum to 1 across each species' fishery fleets or
+# run_mse() refuses to project. Same helper as verify-mse-repro.R.
+activate_proj <- function(dl) {
+  fc <- dl$fleet_control
+  p <- rep(0, nrow(fc))
+  is_fish <- fc$Fleet_type == 1
+  for (s in unique(fc$Species[is_fish])) {
+    idx <- which(is_fish & fc$Species == s)
+    p[idx] <- 1 / length(idx)
+  }
+  dl$fleet_control$Proj_F_proportion <- p
+  dl
+}
+
+data(BS2017SS)
+BS2017SS$projyr <- 2020
+BS2017SS <- activate_proj(BS2017SS)
+
+om <- suppressWarnings(Rceattle::fit_mod(
+  data_list = BS2017SS, inits = NULL, file = NULL, estimateMode = 1,
+  random_rec = FALSE, msmMode = 0,
+  fit_control = fit_control(phase = TRUE, getsd = FALSE, verbose = 0)))
+
+em <- suppressWarnings(Rceattle::fit_mod(
+  data_list = BS2017SS, inits = om$estimated_params, estimateMode = 2,
+  HCR = build_hcr(HCR = 5, Ftarget = 0.4, Flimit = 0.35, Plimit = 0.2,
+                  Alpha = 0.05),
+  msmMode = 0, fit_control = fit_control(getsd = FALSE, verbose = 0)))
+
+ENDYR <- om$data_list$endyr
+NSPP  <- om$data_list$nspp
+stopifnot(ENDYR == 2017)
+
+run <- function(...) suppressMessages(suppressWarnings(Rceattle::run_mse(
+  om = om, em = em, nsim = 1, sampling_period = 1, simulate_data = TRUE,
+  sample_rec = TRUE, regenerate_past = FALSE, seed = 666, cores = 1, ...)))
+
+# Realized catch in the operating model, by year and species. This is what a
+# reduction is supposed to move, and the only thing that distinguishes the
+# scenarios below.
+om_catch <- function(mse) {
+  do.call(rbind, lapply(names(mse), function(nm) {
+    om_i <- mse[[nm]]$OM
+    if (is.null(om_i)) return(NULL)
+    cd <- om_i$data_list$catch_data
+    keep <- cd$Year > ENDYR & cd$Year <= om_i$data_list$endyr
+    data.frame(sim = nm, Year = cd$Year[keep], Species = cd$Species[keep],
+               Catch = cd$Catch[keep])
+  }))
+}
+
+report <- function(label, ok, detail = "") {
+  cat(sprintf("%-58s %s%s\n", label, if (isTRUE(ok)) "PASS" else "FAIL",
+              if (nzchar(detail)) paste0("  [", detail, "]") else ""))
+  invisible(isTRUE(ok))
+}
+
+results <- logical(0)
+
+# --- 1. An explicit schedule equals the period it reproduces ---------------
+# endyr 2017, projyr 2020: period 1 IS c(2018, 2019, 2020). Anything but an
+# exact match means the vector path reaches the loop differently.
+mse_period <- run(assessment_period = 1)
+mse_vector <- run(assessment_period = c(2018, 2019, 2020))
+
+c_period <- om_catch(mse_period)
+c_vector <- om_catch(mse_vector)
+results["equivalence"] <- report(
+  "explicit years == the equivalent period",
+  isTRUE(all.equal(c_period, c_vector, tolerance = 0)),
+  paste0("max |diff| = ",
+         format(max(abs(c_period$Catch - c_vector$Catch)), digits = 3)))
+
+# The assessment nodes are named by year, so the schedule is visible in the
+# returned object rather than only in the caller's script.
+results["names"] <- report(
+  "assessment nodes are named by their year",
+  identical(names(mse_vector$Sim_1$EM),
+            c("EM", paste0("OM_Sim_1. EM_yr_", c(2018, 2019, 2020)))))
+
+# --- 2. A skipped assessment is a shorter schedule, not a longer period ----
+# Assess in 2018 and 2020; the 2019 assessment is missed, so 2019 is fished on
+# 2018's advice and the 2020 assessment covers a two-year interval.
+mse_skip <- run(assessment_period = c(2018, 2020))
+results["skip"] <- report(
+  "a skipped assessment runs one fewer assessment, over the same horizon",
+  length(mse_skip$Sim_1$EM) == 3L &&
+    mse_skip$Sim_1$OM$data_list$endyr == 2020)
+
+# It must not be the same trajectory as assessing in every year.
+results["skip_differs"] <- report(
+  "skipping an assessment changes the trajectory",
+  !isTRUE(all.equal(om_catch(mse_skip)$Catch, c_period$Catch)))
+
+# It must also not be the triennial period it superficially resembles: a period
+# of 2 from 2017 is c(2019), a different schedule over a different horizon.
+results["skip_not_period"] <- report(
+  "a skipped schedule is not the equivalent period",
+  !identical(.mse_assess_years(c(2018, 2020), ENDYR, 2020),
+             .mse_assess_years(2, ENDYR, 2020)))
+
+# --- 3. A year-indexed catch multiplier moves only the years it names ------
+buffer <- expand.grid(Year = 2020, Species = seq_len(NSPP))
+buffer$mult <- 0.5
+
+mse_buffer <- run(assessment_period = 1, catch_mult = buffer)
+c_buffer   <- om_catch(mse_buffer)
+
+# 2018 and 2019 precede the reduction, and the operating model's dynamics in
+# those years are settled before the 2020 catch is ever written, so they must
+# be untouched.
+i_before <- c_period$Year < 2020
+results["year_before"] <- report(
+  "the years before the reduction are bit-identical",
+  isTRUE(all.equal(c_buffer$Catch[i_before], c_period$Catch[i_before],
+                   tolerance = 0)))
+
+# 2020 is halved, up to the exploitable-biomass limit -- which only ever binds
+# downward, so the reduced catch can never come out above the baseline.
+i_of <- c_period$Year == 2020
+results["year_of"] <- report(
+  "the reduction year is cut",
+  all(c_buffer$Catch[i_of] <= c_period$Catch[i_of]) &&
+    any(c_buffer$Catch[i_of] < c_period$Catch[i_of]),
+  paste0("mean ratio = ",
+         format(mean(c_buffer$Catch[i_of] / c_period$Catch[i_of]), digits = 4)))
+
+# --- 4. A vector multiplier still cuts every year --------------------------
+# The contrast that motivates the data.frame form: the same 0.5, supplied as a
+# per-species vector, is a permanent harvest cut and takes 2018 with it.
+mse_flat <- run(assessment_period = 1, catch_mult = rep(0.5, NSPP))
+c_flat   <- om_catch(mse_flat)
+
+results["vector_every_year"] <- report(
+  "a vector multiplier cuts the earlier years too",
+  all(c_flat$Catch[i_before] < c_period$Catch[i_before]),
+  paste0("mean ratio pre-2020 = ",
+         format(mean(c_flat$Catch[i_before] / c_period$Catch[i_before]),
+                digits = 4)))
+
+cat("\n")
+if (all(results)) {
+  cat("verify-mse-schedule: all", length(results), "checks passed\n")
+} else {
+  cat("verify-mse-schedule: FAILED --",
+      paste(names(results)[!results], collapse = ", "), "\n")
+  quit(status = 1)
+}

--- a/vignettes/hcrs-and-mses.Rmd
+++ b/vignettes/hcrs-and-mses.Rmd
@@ -290,6 +290,8 @@ mse7 <- run_mse(
 
 Run these against a baseline that differs *only* in the schedule — same `om`, same `em`, same `seed` — so each replicate sees the same recruitment deviations and the same observation error, and the scenarios can be compared as paired within-replicate differences.
 
+Make the last assessment year reach the projection horizon. Catch is filled only up to the last assessment, so a schedule that stops short leaves the trailing years at `NA` — and `mse_summary()` summarises over the whole projection, understating average catch, catch IAV and P(Closed) with nothing in the table to say so. A biennial cycle over an odd number of projection years lands here every time: `seq(2027, 2050, by = 2)` ends at 2049 against a 2050 horizon. `run_mse()` warns when it happens.
+
 One caveat to carry into any write-up: `catch_mult` multiplies catch, not ABC. A real ABC reduction changes removals only to the extent the fishery attains ABC, and for a stock whose catch sits well below ABC it changes them hardly at all. Either scale the multiplier by recent attainment, `1 - (1 - mult) * attainment`, or report the unscaled result as an upper bound on the effect of the reduction.
 
 ------------------------------------------------------------------------

--- a/vignettes/hcrs-and-mses.Rmd
+++ b/vignettes/hcrs-and-mses.Rmd
@@ -273,22 +273,31 @@ The distinction matters for the answer, not just the bookkeeping. A triennial pe
 
 To pair the gap with a precautionary reduction, give `catch_mult` a `data.frame` of `Year`, `Species` and `mult`. It applies only in the pairs listed, so the reduction can be held for the years advice is stale and lifted once the next assessment lands. `Species` is the species number, and any pair the table omits is multiplied by 1.
 
+Be careful which years those are. The assessment in year `Y` sets catch for `Y+1` onward, so a missed assessment leaves the **two years after it** on the previous assessment's advice — not the missed year itself, which the previous assessment sets in the baseline too.
+
 ```{r, message = FALSE, echo = TRUE, eval = FALSE}
-# 10% reduction over the gap: the missed year and the year that follows it.
-buffer <- expand.grid(Year = miss_yr:(miss_yr + 1),
-                      Species = seq_len(om$data_list$nspp))
+schedule <- setdiff(biennial, miss_yr)
+
+# The years the missed assessment would have set: from the year after it,
+# through the next assessment that was completed.
+gap_yrs <- (miss_yr + 1):min(schedule[schedule > miss_yr])
+
+# 10% reduction, held for exactly those years.
+buffer <- expand.grid(Year = gap_yrs, Species = seq_len(om$data_list$nspp))
 buffer$mult <- 0.90
 
 mse7 <- run_mse(
   om = om, em = em,
   nsim = 10,
-  assessment_period = setdiff(biennial, miss_yr),
+  assessment_period = schedule,
   sampling_period = c(1, 2),
   catch_mult = buffer
 )
 ```
 
-Run these against a baseline that differs *only* in the schedule — same `om`, same `em`, same `seed` — so each replicate sees the same recruitment deviations and the same observation error, and the scenarios can be compared as paired within-replicate differences.
+Run these against a baseline that differs *only* in the schedule — same `om`, same `em`, same `seed` — and compare them as paired within-replicate differences.
+
+Do not expect common random numbers to hold across schedules, though. Between assessments the OM's projection horizon is shortened to the next assessment year, so `sim_mod()` draws over a different number of projection rows depending on the schedule, and the observation draws diverge from the first assessment onward. Recruitment deviations *are* shared — `sample_rec()` draws them once, before the loop — but observation error is not. On a short BS2017SS fixture, dropping one assessment moved catch by 2.1% in a year whose advice was identical by construction. The paired difference therefore still carries Monte Carlo noise; size the replicate count to separate the schedule effect from it, rather than assuming the noise has cancelled.
 
 Make the last assessment year reach the projection horizon. Catch is filled only up to the last assessment, so a schedule that stops short leaves the trailing years at `NA` — and `mse_summary()` summarises over the whole projection, understating average catch, catch IAV and P(Closed) with nothing in the table to say so. A biennial cycle over an odd number of projection years lands here every time: `seq(2027, 2050, by = 2)` ends at 2049 against a 2050 horizon. `run_mse()` warns when it happens.
 

--- a/vignettes/hcrs-and-mses.Rmd
+++ b/vignettes/hcrs-and-mses.Rmd
@@ -115,7 +115,9 @@ arguments fully control reproducibility. (You may still want
 Reproducibility holds *within* a package version, not across one. In 5.9.0 the
 observation draws moved from R into the TMB model, which displaces the
 random-number stream, so a seeded `run_mse()` or `self_test()` will not
-reproduce a run from 5.8.x.
+reproduce a run from 5.8.x. 5.13.0 is the same kind of boundary: the index is
+drawn under the fleet's own `Index_distribution` from that release, which moves
+the stream again.
 
 Two further points when comparing runs. The stream *position* is
 data-dependent: a covariance survey fleet redraws until every row is positive,
@@ -248,6 +250,47 @@ mse4 <- run_mse(
   sampling_period = c(1, 2) # Fishery = fleet 1, BTS = fleet 2
 )
 ```
+
+------------------------------------------------------------------------
+
+## A missed assessment, and a buffer while advice is stale
+
+The scenarios above all set a *period*: an assessment every second or fourth year, for as long as the projection runs. A skipped assessment is a different thing — one gap in an otherwise regular cycle — and `assessment_period` also takes the schedule itself, as a vector of the years an assessment is completed.
+
+```{r, message = FALSE, echo = TRUE, eval = FALSE}
+biennial <- seq(om$data_list$endyr + 2, om$data_list$projyr, by = 2)
+miss_yr  <- biennial[ceiling(length(biennial) / 3)]
+
+mse6 <- run_mse(
+  om = om, em = em,
+  nsim = 10,
+  assessment_period = setdiff(biennial, miss_yr), # every year but miss_yr
+  sampling_period = c(1, 2)
+)
+```
+
+The distinction matters for the answer, not just the bookkeeping. A triennial period is a permanent policy and its cost compounds; one missed assessment is a single episode of stale advice, and how much it costs depends on the state the stock was in when the gap opened.
+
+To pair the gap with a precautionary reduction, give `catch_mult` a `data.frame` of `Year`, `Species` and `mult`. It applies only in the pairs listed, so the reduction can be held for the years advice is stale and lifted once the next assessment lands. `Species` is the species number, and any pair the table omits is multiplied by 1.
+
+```{r, message = FALSE, echo = TRUE, eval = FALSE}
+# 10% reduction over the gap: the missed year and the year that follows it.
+buffer <- expand.grid(Year = miss_yr:(miss_yr + 1),
+                      Species = seq_len(om$data_list$nspp))
+buffer$mult <- 0.90
+
+mse7 <- run_mse(
+  om = om, em = em,
+  nsim = 10,
+  assessment_period = setdiff(biennial, miss_yr),
+  sampling_period = c(1, 2),
+  catch_mult = buffer
+)
+```
+
+Run these against a baseline that differs *only* in the schedule — same `om`, same `em`, same `seed` — so each replicate sees the same recruitment deviations and the same observation error, and the scenarios can be compared as paired within-replicate differences.
+
+One caveat to carry into any write-up: `catch_mult` multiplies catch, not ABC. A real ABC reduction changes removals only to the extent the fishery attains ABC, and for a stock whose catch sits well below ABC it changes them hardly at all. Either scale the multiplier by recent attainment, `1 - (1 - mult) * attainment`, or report the unscaled result as an upper bound on the effect of the reduction.
 
 ------------------------------------------------------------------------
 

--- a/vignettes/model-options-and-functionality.Rmd
+++ b/vignettes/model-options-and-functionality.Rmd
@@ -572,7 +572,7 @@ See `?build_hcr` for more details.
 | `fit_mod(estimateMode = 2, HCR = build_hcr(...))` | Forward projection under a fixed HCR |
 | `sample_rec()` | Bootstrap historical recruitment deviations (with optional `rec_trend`) into the projection |
 | `remove_F()` | Refit a model with F = 0 (used internally for dynamic reference points) |
-| `run_mse()` | Closed-loop MSE: refit EM at intervals of `assessment_period`, sample new data at `sampling_period` |
+| `run_mse()` | Closed-loop MSE: refit EM on the `assessment_period` schedule (a period, or the years themselves), sample new data at `sampling_period` |
 | `load_mse()` | Reload per-simulation `.rds` files written when `dir =` is supplied |
 | `check_mse()` | Validate which OM/EM simulations converged |
 | `mse_summary()` | Per-fleet performance metrics: mean catch, IAV, P(closed), P(F > Flimit), P(SSB < SSBlimit), terminal depletion |


### PR DESCRIPTION
Two `run_mse()` arguments the September GOA MSE appendix needs, plus what verifying them turned up.

## What it adds

**`assessment_period` takes an explicit vector of assessment years.** A single number is the period it always was; a vector is the schedule itself.

```r
biennial <- seq(om$data_list$endyr + 2, om$data_list$projyr, by = 2)
run_mse(om, em, assessment_period = setdiff(biennial, 2031))
```

A skipped assessment is one gap in an otherwise regular cycle, and a period cannot express it. Standing a triennial period in for a missed biennial assessment answers a different question, and the error is not signed: it overstates how the cost of stale advice compounds while being blind to the state the stock was in when the single gap opened.

**`catch_mult` takes a `data.frame` of `Year`, `Species` and `mult`.** The scalar/vector form is unchanged and applies in every projection year — a permanent harvest cut, which cannot express a buffer held only while advice is stale.

```r
buffer <- expand.grid(Year = 2032:2033, Species = seq_len(om$data_list$nspp))
buffer$mult <- 0.90
run_mse(om, em, assessment_period = setdiff(biennial, 2031), catch_mult = buffer)
```

## Validation, and why it is there

Every way the table can be wrong otherwise reads as *no reduction* in a run that finishes and looks ordinary — `match()` returns `NA` for an unmatched pair and takes the first of a duplicated one. So a year outside the schedule, a species number out of range, a duplicated pair, and a non-finite or negative multiplier are all errors at the call.

The year bound is the **last assessment year**, not `projyr`: catch is filled only up to the last assessment, so a multiplier named for a later year sits inside the projection and still applies nowhere.

A schedule must name **two or more** years — one year cannot be told from a period, and the two readings of `2029` are a world apart.

## A defect this surfaced

**A schedule that stops short of the projection horizon now warns.** Catch is filled only to the last assessment, so trailing years keep `NA` — and `mse_summary()` summarises over the models' whole `projyr` regardless. Those `NA` years sit in the denominator of `P(Closed)` but not its numerator, in both halves of `Catch IAV`, and outside the `na.rm` mean that is `Average Catch`. All three come out low with nothing in the table saying which years were covered.

A biennial cycle over an odd number of projection years lands here every time: `seq(2027, 2050, by = 2)` ends at 2049 against a 2050 horizon. Pre-existing for scalar periods; the vector API makes the terminal year an explicit choice, so the guard belongs here.

## A limitation this documents but does not change

**Two schedules on the same `seed` are not on common random numbers.** Between assessments the OM's projection horizon is shortened to the next assessment year, so `sim_mod()` draws over a different number of projection rows depending on the schedule, and the observation draws diverge from the first assessment onward.

Measured on the three-year BS2017SS fixture — dropping the 2019 assessment, whose 2019 advice is identical by construction (both schedules set 2019 from the same 2018 assessment):

| Year | full schedule | 2019 skipped |
|---|---|---|
| 2018 | 4,139,681 | 4,139,681 |
| 2019 | 2,880,119 | **2,941,211** (+2.1%) |
| 2020 | 1,922,518 | 2,005,049 |

Recruitment deviations *are* shared — `sample_rec()` draws them before the loop — but observation error is not. A paired comparison of two schedules therefore carries an observation-error difference alongside the schedule effect.

Left as it behaves: making the draw schedule-independent would move every seeded `run_mse()` result and deserves its own change. It is now documented in `?run_mse` and `vignette("hcrs-and-mses")`, and pinned in the harness so a future fix fails loudly and says why.

## Verification

- **`tools/verify/verify-mse-schedule.R` (new) — 13/13.** Real closed loop on BS2017SS. A schedule given as years reproduces the equivalent period at **max |diff| = 0**; the years before a reduction are bit-identical; the reduction year comes out at a mean ratio of **0.500** under `mult = 0.5`.
- **`tests/testthat/test-mse-schedule-and-catch-mult.R` (new) — 41 assertions.**
- **Full suite clean**, 3 skips, on the rebased tree.
- `document()` rewrote `run_mse.Rd` only; no `NAMESPACE` churn. `_pkgdown.yml` needs nothing.
- **Ecosystem sweep clean.** Every `run_mse()` call in `../Rceattle-models` and `../GOA-ATF-ESP` passes `assessment_period = 1` or `2`; no `catch_mult` anywhere. No existing call changes behaviour.

## Notes for review

- Rebased onto `dev` at `a9806f54`; `NEWS.md` keeps 5.17.0, 5.16.0 and 5.15.0 newest-first.
- `catch_mult` multiplies **catch, not ABC**. Where realized catch sits below ABC — GOA arrowtooth above all — reducing ABC changes removals only to the extent the fishery attains it. `?run_mse` and the vignette both carry the caveat.
