### PR TITLE
Check maturity and sex_ratio age coverage per species

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rceattle
 Title: Fits the Multispecies Assessment Model (CEATTLE) Using TMB
-Version: 5.18.1
+Version: 5.19.0
 Authors@R:
     person(given = "Grant",
            family = "Adams",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,38 @@ intermediate. Note the folding rather than renumbering: a section for a version 
 never carries breaks any (x.y.z) cross-reference pointing at it.
 -->
 
+# Rceattle 5.19.0
+
+## Bug fixes
+
+* **`data_check()` checks `maturity` and `sex_ratio` age coverage per species,
+  not only against the widest one.** The existing checks compare the table's
+  column count with `max(nages)`, so a table wide enough for the longest-lived
+  species passes even when a shorter-column species is left short of its own
+  bins — and the `[0, 1]` range check then reads over the `NA`s with `na.rm`.
+
+  `spawning_biomass_per_recruit()` (`src/TMB/spr.hpp`) sums across every age of
+  a species and scales by the proportion female, so one gap inside a species'
+  own age range makes `SPR0` `NA`, and with it `SPRtarget`, `SPRlimit` and every
+  SPR-based reference point. Nothing else reads those tables the same way — the
+  hindcast uses the sex ratio it estimates — so a model fits cleanly until a
+  harvest control rule asks for reference points, and then `nlminb` reports
+  `NA/NaN gradient evaluation`, naming neither the table nor the species.
+
+  Found on the GOA multispecies workbook, where arrowtooth `sex_ratio` was
+  filled to Age10 against 21 age bins. That same data now reports:
+
+  ```
+  sex_ratio is missing values for species 2, ages 11-21; that species has 21
+  age bins. Spawner-per-recruit sums over every age, so a gap leaves SPR0 and
+  the reference points NA.
+  ```
+
+  Ages past a species' own `nages` are padding and are not checked, so a ragged
+  multispecies workbook still passes — asserted against the bundled datasets in
+  `test-data-check-age-coverage.R`.
+
+
 # Rceattle 5.18.1
 
 ## Documentation

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,26 +21,42 @@ never carries breaks any (x.y.z) cross-reference pointing at it.
   species passes even when a shorter-column species is left short of its own
   bins — and the `[0, 1]` range check then reads over the `NA`s with `na.rm`.
 
-  `spawning_biomass_per_recruit()` (`src/TMB/spr.hpp`) sums across every age of
-  a species and scales by the proportion female, so one gap inside a species'
-  own age range makes `SPR0` `NA`, and with it `SPRtarget`, `SPRlimit` and every
-  SPR-based reference point. Nothing else reads those tables the same way — the
-  hindcast uses the sex ratio it estimates — so a model fits cleanly until a
-  harvest control rule asks for reference points, and then `nlminb` reports
-  `NA/NaN gradient evaluation`, naming neither the table nor the species.
+  Both tables are summed over age. `mature_females` is `maturity`, times
+  `sex_ratio` where a species is modelled one-sex (`ceattle.cpp` 5.4), and feeds
+  hindcast `ssb`; `spawning_biomass_per_recruit()` (`src/TMB/spr.hpp`) sums the
+  same schedule for SPR. So a `maturity` gap makes SSB `NA` for any species, and
+  a `sex_ratio` gap does the same for a **one-sex** species.
+
+  On a **two-sex** species `sex_ratio` reaches only SPR — which is how this one
+  hid: the model fits cleanly, and the failure waits until a harvest control
+  rule asks for reference points, when `nlminb` reports `NA/NaN gradient
+  evaluation`, naming neither the table nor the species.
 
   Found on the GOA multispecies workbook, where arrowtooth `sex_ratio` was
   filled to Age10 against 21 age bins. That same data now reports:
 
   ```
-  sex_ratio is missing values for species 2, ages 11-21; that species has 21
-  age bins. Spawner-per-recruit sums over every age, so a gap leaves SPR0 and
-  the reference points NA.
+  sex_ratio is missing values for species 2, ages 11-21 of 21. Spawning
+  biomass and spawner-per-recruit both sum over every age, so a gap leaves
+  SSB or SPR0 NA.
   ```
 
   Ages past a species' own `nages` are padding and are not checked, so a ragged
   multispecies workbook still passes — asserted against the bundled datasets in
   `test-data-check-age-coverage.R`.
+
+  Rows are read by **position**, since `rearrange_data()` drops the `Species`
+  column and hands the model a matrix whose row *i* is species *i*. A
+  `Species` column that disagrees with the row order, and a table with fewer
+  rows than species, are both reported.
+
+* **An `NA` in `nages` no longer aborts `data_check()`.** Five age-coverage
+  comparisons (`weight`, `ration_data`, `age_error`, `maturity`/`sex_ratio`
+  widths, `NByageFixed`, CAAL columns) evaluated `any(... < nages)` or
+  `max(nages)` without `na.rm`, so a single `NA` made the `if()` condition `NA`
+  and raised "missing value where TRUE/FALSE needed" — discarding every error
+  accumulated up to that point, including `nages`' own "not included for all
+  species".
 
 
 # Rceattle 5.18.1

--- a/R/1-data_check.R
+++ b/R/1-data_check.R
@@ -431,44 +431,83 @@ data_check <- function(data_list) {
   }
 
   # Weight / maturity / sex_ratio age coverage
+  # na.rm: an NA in `nages` is reported by the check that owns it, and without
+  # this `any()` returns NA and the `if` aborts data_check() -- discarding every
+  # error accumulated so far, that one included.
   if(any(data_list$weight |>
          dplyr::select(-c(Wt_name, Wt_index, Species, Sex, Year)) |>
-         ncol() < data_list$nages)){
+         ncol() < data_list$nages, na.rm = TRUE)){
     errors <- c(errors, "Weight data does not span range of ages")
   }
-  if(ncol(data_list$maturity)  <= max(data_list$nages)) errors <- c(errors, "Maturity-at-age (maturity) does not span all ages")
-  if(ncol(data_list$sex_ratio) <= max(data_list$nages)) errors <- c(errors, "Sex ratio does not span all ages")
+  # na.rm on the max for the same reason as the weight check above: one NA in
+  # `nages` would otherwise abort data_check() here instead of being reported.
+  max_ages <- suppressWarnings(max(data_list$nages, na.rm = TRUE))
+  if(is.finite(max_ages)){
+    if(ncol(data_list$maturity)  <= max_ages) errors <- c(errors, "Maturity-at-age (maturity) does not span all ages")
+    if(ncol(data_list$sex_ratio) <= max_ages) errors <- c(errors, "Sex ratio does not span all ages")
+  }
 
   # Per-species age coverage, which the column counts above cannot see. Those
   # ask only whether the table is wide enough for the LONGEST-lived species, so
   # a table can be wide enough and still leave a species' own bins empty -- and
   # the value-range checks below pass over NA.
   #
-  # Spawner-per-recruit sums across every age of a species and scales by the
-  # proportion female (`spr.hpp`), so one gap inside a species' own age range
-  # makes SPR0 NA, and with it every SPR-based reference point. The only symptom
-  # is a non-finite gradient out of the reference-point solve -- nlminb's
-  # "NA/NaN gradient evaluation", which names neither the table nor the species.
+  # Both tables are summed over age. `mature_females` is `maturity`, times
+  # `sex_ratio` where a species is modelled one-sex (`ceattle.cpp` 5.4), and
+  # feeds hindcast `ssb`; `spawning_biomass_per_recruit()` (`spr.hpp`) sums the
+  # same schedule for SPR. So a `maturity` gap makes SSB NaN for any species,
+  # and a `sex_ratio` gap does the same for a ONE-SEX species. On a two-sex
+  # species `sex_ratio` reaches only SPR, which is why such a gap can sit
+  # unnoticed until a harvest control rule asks for reference points and nlminb
+  # reports "NA/NaN gradient evaluation", naming neither table nor species.
+  #
+  # Rows are read by POSITION: rearrange_data() drops the Species column and
+  # hands the template a matrix whose row i IS species i. A Species column that
+  # disagrees with the row order is reported rather than followed.
+  #
   # Ages beyond a species' own `nages` are padding and are not checked.
+  fmt_ages <- function(x){
+    if(length(x) > 1L && identical(x, seq(x[1L], x[length(x)]))){
+      paste0(x[1L], "-", x[length(x)])
+    } else paste(x, collapse = ", ")
+  }
   for(nm in c("maturity", "sex_ratio")){
     tbl <- data_list[[nm]]
     if(is.null(tbl) || !nrow(tbl)) next
     agec <- grep("^Age", colnames(tbl))
     if(!length(agec)) next
-    spp_col <- if(!is.null(tbl$Species)) tbl$Species else tbl[[1]]
-    for(i in seq_len(nrow(tbl))){
-      sp <- suppressWarnings(as.integer(spp_col[i]))
-      if(is.na(sp) || sp < 1 || sp > data_list$nspp) next
+
+    if(nrow(tbl) < data_list$nspp){
+      errors <- c(errors, paste0(
+        nm, " has ", nrow(tbl), " row(s) for ", data_list$nspp, " species. Rows ",
+        "are read by position, so species ", nrow(tbl) + 1L,
+        if(data_list$nspp > nrow(tbl) + 1L) paste0("-", data_list$nspp) else "",
+        " would be read past the end of the table."))
+    }
+    if(!is.null(tbl$Species)){
+      out_of_order <- which(suppressWarnings(as.integer(tbl$Species)) !=
+                              seq_len(nrow(tbl)))
+      if(length(out_of_order)){
+        errors <- c(errors, paste0(
+          nm, "$Species must match the row order -- rearrange_data() drops the ",
+          "column and the template reads row i as species i. Row(s) ",
+          paste(out_of_order, collapse = ", "), " disagree."))
+      }
+    }
+
+    for(sp in seq_len(min(nrow(tbl), data_list$nspp))){
       n <- data_list$nages[sp]
-      if(length(agec) < n) next   # the column-count check above already reports it
-      vals <- suppressWarnings(as.numeric(tbl[i, agec[seq_len(n)]]))
+      # NA `nages`, or a table too narrow: both are reported by the checks that
+      # own them, and `if(NA)` here would abort before any of them are raised.
+      if(is.na(n) || length(agec) < n) next
+      vals <- suppressWarnings(as.numeric(tbl[sp, agec[seq_len(n)]]))
       gaps <- which(!is.finite(vals))
       if(length(gaps)){
         errors <- c(errors, paste0(
           nm, " is missing values for species ", sp, ", age",
-          if(length(gaps) > 1) "s " else " ", paste(range(gaps), collapse = "-"),
-          "; that species has ", n, " age bins. Spawner-per-recruit sums over ",
-          "every age, so a gap leaves SPR0 and the reference points NA."))
+          if(length(gaps) > 1L) "s " else " ", fmt_ages(gaps),
+          " of ", n, ". Spawning biomass and spawner-per-recruit both sum over ",
+          "every age, so a gap leaves SSB or SPR0 NA."))
       }
     }
   }
@@ -515,9 +554,11 @@ data_check <- function(data_list) {
 
   # ration_data
   if(has_data(data_list$ration_data)){
+    # na.rm as for weight above: an NA in `nages` is reported by its own check
+    # and must not abort this one.
     if(any(data_list$ration_data |>
            dplyr::select(-c(Species, Sex, Year)) |>
-           ncol() < data_list$nages)){
+           ncol() < data_list$nages, na.rm = TRUE)){
       errors <- c(errors, "'ration_data' data does not span range of ages")
     }
     ration_sex <- data_list$ration_data |> dplyr::group_by(Species) |>
@@ -544,7 +585,7 @@ data_check <- function(data_list) {
   if(any(data_list$age_error |>
          as.data.frame() |>
          dplyr::select(-c(Species, True_age)) |>
-         ncol() < data_list$nages)){
+         ncol() < data_list$nages, na.rm = TRUE)){
     errors <- c(errors, "`age_error` observed ages do not span range of ages")
   }
   # ALK & age_error: per-species age coverage (fillable with 0s downstream -- message-level)
@@ -590,11 +631,11 @@ data_check <- function(data_list) {
   # table); the column-count adequacy check stays imperative below.
   errors <- c(errors, .rce_check_presence(data_list, "NByageFixed"))
   if(any(data_list$estDynamics > 0) && has_data(data_list$NByageFixed)){
-    expected_cols <- 4 + max(data_list$nages)
+    expected_cols <- 4 + suppressWarnings(max(data_list$nages, na.rm = TRUE))
     if(ncol(data_list$NByageFixed) != expected_cols){
       errors <- c(errors, paste0("NByageFixed should have ", expected_cols,
                                  " columns (Species_name, Species, Sex, Year, Age1...Age",
-                                 max(data_list$nages), "), but has ", ncol(data_list$NByageFixed)))
+                                 suppressWarnings(max(data_list$nages, na.rm = TRUE)), "), but has ", ncol(data_list$NByageFixed)))
     }
   }
 
@@ -1559,7 +1600,7 @@ data_check <- function(data_list) {
     if(length(caal_cols) == 0){
       errors <- c(errors, "caal_data is missing CAAL_ columns (CAAL_1, CAAL_2, etc.)")
     } else {
-      missing_caal <- setdiff(paste0("CAAL_", 1:max(data_list$nages)), caal_cols)
+      missing_caal <- setdiff(paste0("CAAL_", 1:suppressWarnings(max(data_list$nages, na.rm = TRUE))), caal_cols)
       if(length(missing_caal) > 0){
         errors <- c(errors, paste("caal_data is missing CAAL columns:",
                                   paste(missing_caal, collapse = ", ")))

--- a/R/1-data_check.R
+++ b/R/1-data_check.R
@@ -462,7 +462,7 @@ data_check <- function(data_list) {
   # reports "NA/NaN gradient evaluation", naming neither table nor species.
   #
   # Rows are read by POSITION: rearrange_data() drops the Species column and
-  # hands the template a matrix whose row i IS species i. A Species column that
+  # hands the model a matrix whose row i IS species i. A Species column that
   # disagrees with the row order is reported rather than followed.
   #
   # Ages beyond a species' own `nages` are padding and are not checked.
@@ -490,7 +490,7 @@ data_check <- function(data_list) {
       if(length(out_of_order)){
         errors <- c(errors, paste0(
           nm, "$Species must match the row order -- rearrange_data() drops the ",
-          "column and the template reads row i as species i. Row(s) ",
+          "column and the model reads row i as species i. Row(s) ",
           paste(out_of_order, collapse = ", "), " disagree."))
       }
     }

--- a/R/1-data_check.R
+++ b/R/1-data_check.R
@@ -439,6 +439,40 @@ data_check <- function(data_list) {
   if(ncol(data_list$maturity)  <= max(data_list$nages)) errors <- c(errors, "Maturity-at-age (maturity) does not span all ages")
   if(ncol(data_list$sex_ratio) <= max(data_list$nages)) errors <- c(errors, "Sex ratio does not span all ages")
 
+  # Per-species age coverage, which the column counts above cannot see. Those
+  # ask only whether the table is wide enough for the LONGEST-lived species, so
+  # a table can be wide enough and still leave a species' own bins empty -- and
+  # the value-range checks below pass over NA.
+  #
+  # Spawner-per-recruit sums across every age of a species and scales by the
+  # proportion female (`spr.hpp`), so one gap inside a species' own age range
+  # makes SPR0 NA, and with it every SPR-based reference point. The only symptom
+  # is a non-finite gradient out of the reference-point solve -- nlminb's
+  # "NA/NaN gradient evaluation", which names neither the table nor the species.
+  # Ages beyond a species' own `nages` are padding and are not checked.
+  for(nm in c("maturity", "sex_ratio")){
+    tbl <- data_list[[nm]]
+    if(is.null(tbl) || !nrow(tbl)) next
+    agec <- grep("^Age", colnames(tbl))
+    if(!length(agec)) next
+    spp_col <- if(!is.null(tbl$Species)) tbl$Species else tbl[[1]]
+    for(i in seq_len(nrow(tbl))){
+      sp <- suppressWarnings(as.integer(spp_col[i]))
+      if(is.na(sp) || sp < 1 || sp > data_list$nspp) next
+      n <- data_list$nages[sp]
+      if(length(agec) < n) next   # the column-count check above already reports it
+      vals <- suppressWarnings(as.numeric(tbl[i, agec[seq_len(n)]]))
+      gaps <- which(!is.finite(vals))
+      if(length(gaps)){
+        errors <- c(errors, paste0(
+          nm, " is missing values for species ", sp, ", age",
+          if(length(gaps) > 1) "s " else " ", paste(range(gaps), collapse = "-"),
+          "; that species has ", n, " age bins. Spawner-per-recruit sums over ",
+          "every age, so a gap leaves SPR0 and the reference points NA."))
+      }
+    }
+  }
+
   # Maturity / sex_ratio value ranges
   mat_vals <- data_list$maturity[, grep("^Age", colnames(data_list$maturity)), drop = FALSE]
   if(any(mat_vals < 0, na.rm = TRUE)){ # | mat_vals > 1

--- a/tests/testthat/test-data-check-age-coverage.R
+++ b/tests/testthat/test-data-check-age-coverage.R
@@ -83,7 +83,7 @@ test_that("scattered gaps are listed, not reported as a span", {
 
 
 test_that("rows are read by position, and a disagreeing Species column is reported", {
-  # rearrange_data() drops Species and hands the template a row-indexed matrix,
+  # rearrange_data() drops Species and hands the model a row-indexed matrix,
   # so row i IS species i. Following the column instead would check the wrong
   # species' nages.
   dl <- goa()

--- a/tests/testthat/test-data-check-age-coverage.R
+++ b/tests/testthat/test-data-check-age-coverage.R
@@ -1,0 +1,124 @@
+# Per-species age coverage in `maturity` and `sex_ratio`.
+#
+# Provenance: the GOA multispecies workbook filled arrowtooth `sex_ratio` only
+# to Age10 while that species carries 21 age bins. The table was still wider
+# than max(nages), so the column-count check passed, and the [0, 1] range check
+# uses na.rm so the NAs passed too.
+#
+# spawning_biomass_per_recruit() (src/TMB/spr.hpp) sums over every age of the
+# species and multiplies by the proportion female, so the gap made SPR0 NA for
+# that species -- and with it SPRtarget and SPRlimit. A Tier 3 HCR solves for
+# the F achieving a share of SPR0, so the reference-point solve got a NaN
+# gradient on its first evaluation and nlminb reported "NA/NaN gradient
+# evaluation", naming neither the table nor the species. The hindcast reads its
+# own estimated sex ratio rather than this table, so the same model fit cleanly
+# with no HCR: the defect was invisible until reference points were asked for.
+
+# A two-species fixture: species 1 has 3 age bins, species 2 has 6. The table
+# is wide enough for the longer species, which is what makes the column-count
+# check insufficient.
+age_tbl <- function(vals) {
+  d <- as.data.frame(vals)
+  colnames(d) <- paste0("Age", seq_len(ncol(d)))
+  cbind(Species = seq_len(nrow(d)), d)
+}
+
+base_dl <- function() {
+  list(
+    nspp  = 2,
+    nages = c(3, 6),
+    maturity  = age_tbl(rbind(c(0, .5, 1, NA, NA, NA),
+                              c(0, .2, .5, .8, .9, 1))),
+    sex_ratio = age_tbl(rbind(c(.5, .5, .5, NA, NA, NA),
+                              c(.5, .5, .5, .5, .5, .5)))
+  )
+}
+
+# The checks under test, lifted so the fixture does not need a whole data_list.
+# Keep in lockstep with the "Per-species age coverage" block in R/1-data_check.R.
+coverage_errors <- function(data_list) {
+  errors <- character(0)
+  for (nm in c("maturity", "sex_ratio")) {
+    tbl <- data_list[[nm]]
+    if (is.null(tbl) || !nrow(tbl)) next
+    agec <- grep("^Age", colnames(tbl))
+    if (!length(agec)) next
+    spp_col <- if (!is.null(tbl$Species)) tbl$Species else tbl[[1]]
+    for (i in seq_len(nrow(tbl))) {
+      sp <- suppressWarnings(as.integer(spp_col[i]))
+      if (is.na(sp) || sp < 1 || sp > data_list$nspp) next
+      n <- data_list$nages[sp]
+      if (length(agec) < n) next
+      vals <- suppressWarnings(as.numeric(tbl[i, agec[seq_len(n)]]))
+      gaps <- which(!is.finite(vals))
+      if (length(gaps)) {
+        errors <- c(errors, paste0(
+          nm, " is missing values for species ", sp, ", age",
+          if (length(gaps) > 1) "s " else " ", paste(range(gaps), collapse = "-"),
+          "; that species has ", n, " age bins."))
+      }
+    }
+  }
+  errors
+}
+
+
+test_that("padding past a species' own nages is not an error", {
+  # Species 1 has 3 age bins in a 6-column table. Ages 4-6 are NA and must
+  # stay legal -- every ragged multispecies workbook looks like this.
+  expect_length(coverage_errors(base_dl()), 0)
+})
+
+
+test_that("a gap inside a species' own age range is caught", {
+  dl <- base_dl()
+  # The arrowtooth case: filled to age 3, NA for 4-6, but the species has 6.
+  dl$sex_ratio[2, c("Age4", "Age5", "Age6")] <- NA
+
+  err <- coverage_errors(dl)
+  expect_length(err, 1)
+  expect_match(err, "sex_ratio")
+  expect_match(err, "species 2")
+  expect_match(err, "ages 4-6")
+  expect_match(err, "6 age bins")
+})
+
+
+test_that("the same gap in maturity is caught, and one age reads as singular", {
+  dl <- base_dl()
+  dl$maturity[2, "Age5"] <- NA
+
+  err <- coverage_errors(dl)
+  expect_length(err, 1)
+  expect_match(err, "maturity is missing values for species 2, age 5-5")
+})
+
+
+test_that("gaps in both tables are reported separately", {
+  dl <- base_dl()
+  dl$sex_ratio[2, "Age6"] <- NA
+  dl$maturity[2, "Age2"]  <- NA
+  expect_length(coverage_errors(dl), 2)
+})
+
+
+test_that("the column-count case is left to the check that owns it", {
+  # Too few Age columns for the longer species: the ncol() check reports that,
+  # and this block must not pile a second error on the same cause.
+  dl <- base_dl()
+  dl$sex_ratio <- dl$sex_ratio[, c("Species", paste0("Age", 1:3))]
+  dl$maturity  <- dl$maturity[,  c("Species", paste0("Age", 1:3))]
+  expect_length(coverage_errors(dl), 0)
+})
+
+
+test_that("every bundled dataset passes", {
+  # The guard against a false positive on real ragged data.
+  for (nm in c("BS2017SS", "BS2017MS", "GOA2018SS", "NorthernRockfish2022")) {
+    dl <- tryCatch(get(utils::data(list = nm, package = "Rceattle",
+                                   envir = environment())),
+                   error = function(e) NULL)
+    if (is.null(dl)) next
+    expect_length(coverage_errors(dl), 0)
+  }
+})

--- a/tests/testthat/test-data-check-age-coverage.R
+++ b/tests/testthat/test-data-check-age-coverage.R
@@ -1,124 +1,126 @@
-# Per-species age coverage in `maturity` and `sex_ratio`.
+# Per-species age coverage in `maturity` and `sex_ratio`, exercised through
+# data_check() itself rather than a transcription of it.
 #
-# Provenance: the GOA multispecies workbook filled arrowtooth `sex_ratio` only
-# to Age10 while that species carries 21 age bins. The table was still wider
-# than max(nages), so the column-count check passed, and the [0, 1] range check
-# uses na.rm so the NAs passed too.
+# Provenance: the GOA multispecies workbook had the arrowtooth `sex_ratio` for
+# ages 11-21 pasted 20 columns right of its Age11..Age21 home, leaving those
+# columns empty against 21 age bins. The table was still wider than
+# max(nages), so the column-count check passed, and the [0, 1] range check uses
+# na.rm so the NAs passed too.
 #
-# spawning_biomass_per_recruit() (src/TMB/spr.hpp) sums over every age of the
-# species and multiplies by the proportion female, so the gap made SPR0 NA for
-# that species -- and with it SPRtarget and SPRlimit. A Tier 3 HCR solves for
-# the F achieving a share of SPR0, so the reference-point solve got a NaN
-# gradient on its first evaluation and nlminb reported "NA/NaN gradient
-# evaluation", naming neither the table nor the species. The hindcast reads its
-# own estimated sex ratio rather than this table, so the same model fit cleanly
-# with no HCR: the defect was invisible until reference points were asked for.
+# What reads these tables: `mature_females` is `maturity`, times `sex_ratio`
+# where a species is modelled one-sex (ceattle.cpp 5.4), and feeds hindcast
+# `ssb`; spawning_biomass_per_recruit() (spr.hpp) sums the same schedule for
+# SPR. So a `maturity` gap makes SSB NaN for any species, and a `sex_ratio` gap
+# does so for a one-sex species. On a TWO-SEX species -- arrowtooth -- a
+# `sex_ratio` gap reaches only SPR, so the model fit cleanly until a Tier 3 rule
+# asked for reference points and nlminb returned "NA/NaN gradient evaluation",
+# naming neither table nor species.
 
-# A two-species fixture: species 1 has 3 age bins, species 2 has 6. The table
-# is wide enough for the longer species, which is what makes the column-count
-# check insufficient.
-age_tbl <- function(vals) {
-  d <- as.data.frame(vals)
-  colnames(d) <- paste0("Age", seq_len(ncol(d)))
-  cbind(Species = seq_len(nrow(d)), d)
+# A bundled multispecies data_list, which passes data_check() as shipped.
+goa <- function() {
+  e <- new.env()
+  utils::data("GOA2018SS", package = "Rceattle", envir = e)
+  get("GOA2018SS", envir = e)
 }
 
-base_dl <- function() {
-  list(
-    nspp  = 2,
-    nages = c(3, 6),
-    maturity  = age_tbl(rbind(c(0, .5, 1, NA, NA, NA),
-                              c(0, .2, .5, .8, .9, 1))),
-    sex_ratio = age_tbl(rbind(c(.5, .5, .5, NA, NA, NA),
-                              c(.5, .5, .5, .5, .5, .5)))
-  )
+check_err <- function(dl) {
+  tryCatch({
+    suppressWarnings(suppressMessages(data_check(dl)))
+    character(0)
+  }, error = function(e) conditionMessage(e))
 }
 
-# The checks under test, lifted so the fixture does not need a whole data_list.
-# Keep in lockstep with the "Per-species age coverage" block in R/1-data_check.R.
-coverage_errors <- function(data_list) {
-  errors <- character(0)
-  for (nm in c("maturity", "sex_ratio")) {
-    tbl <- data_list[[nm]]
-    if (is.null(tbl) || !nrow(tbl)) next
-    agec <- grep("^Age", colnames(tbl))
-    if (!length(agec)) next
-    spp_col <- if (!is.null(tbl$Species)) tbl$Species else tbl[[1]]
-    for (i in seq_len(nrow(tbl))) {
-      sp <- suppressWarnings(as.integer(spp_col[i]))
-      if (is.na(sp) || sp < 1 || sp > data_list$nspp) next
-      n <- data_list$nages[sp]
-      if (length(agec) < n) next
-      vals <- suppressWarnings(as.numeric(tbl[i, agec[seq_len(n)]]))
-      gaps <- which(!is.finite(vals))
-      if (length(gaps)) {
-        errors <- c(errors, paste0(
-          nm, " is missing values for species ", sp, ", age",
-          if (length(gaps) > 1) "s " else " ", paste(range(gaps), collapse = "-"),
-          "; that species has ", n, " age bins."))
-      }
-    }
-  }
-  errors
-}
+age_cols <- function(tbl) grep("^Age", colnames(tbl))
 
 
-test_that("padding past a species' own nages is not an error", {
-  # Species 1 has 3 age bins in a 6-column table. Ages 4-6 are NA and must
-  # stay legal -- every ragged multispecies workbook looks like this.
-  expect_length(coverage_errors(base_dl()), 0)
-})
-
-
-test_that("a gap inside a species' own age range is caught", {
-  dl <- base_dl()
-  # The arrowtooth case: filled to age 3, NA for 4-6, but the species has 6.
-  dl$sex_ratio[2, c("Age4", "Age5", "Age6")] <- NA
-
-  err <- coverage_errors(dl)
-  expect_length(err, 1)
-  expect_match(err, "sex_ratio")
-  expect_match(err, "species 2")
-  expect_match(err, "ages 4-6")
-  expect_match(err, "6 age bins")
-})
-
-
-test_that("the same gap in maturity is caught, and one age reads as singular", {
-  dl <- base_dl()
-  dl$maturity[2, "Age5"] <- NA
-
-  err <- coverage_errors(dl)
-  expect_length(err, 1)
-  expect_match(err, "maturity is missing values for species 2, age 5-5")
-})
-
-
-test_that("gaps in both tables are reported separately", {
-  dl <- base_dl()
-  dl$sex_ratio[2, "Age6"] <- NA
-  dl$maturity[2, "Age2"]  <- NA
-  expect_length(coverage_errors(dl), 2)
-})
-
-
-test_that("the column-count case is left to the check that owns it", {
-  # Too few Age columns for the longer species: the ncol() check reports that,
-  # and this block must not pile a second error on the same cause.
-  dl <- base_dl()
-  dl$sex_ratio <- dl$sex_ratio[, c("Species", paste0("Age", 1:3))]
-  dl$maturity  <- dl$maturity[,  c("Species", paste0("Age", 1:3))]
-  expect_length(coverage_errors(dl), 0)
-})
-
-
-test_that("every bundled dataset passes", {
-  # The guard against a false positive on real ragged data.
-  for (nm in c("BS2017SS", "BS2017MS", "GOA2018SS", "NorthernRockfish2022")) {
-    dl <- tryCatch(get(utils::data(list = nm, package = "Rceattle",
-                                   envir = environment())),
-                   error = function(e) NULL)
+test_that("the shipped datasets pass, ragged padding and all", {
+  # The false-positive guard. These carry species with different nages in one
+  # table, so every row has NA padding past its own bins -- which must stay
+  # legal or data_check() would reject real workbooks.
+  for (nm in c("BS2017SS", "BS2017MS", "GOA2018SS")) {
+    e <- new.env()
+    dl <- tryCatch({
+      utils::data(list = nm, package = "Rceattle", envir = e); get(nm, envir = e)
+    }, error = function(e) NULL)
     if (is.null(dl)) next
-    expect_length(coverage_errors(dl), 0)
+    expect_false(grepl("missing values for species", paste(check_err(dl), collapse = " ")),
+                 info = nm)
   }
+})
+
+
+test_that("a sex_ratio gap inside a species' own ages is named", {
+  dl <- goa()
+  ac <- age_cols(dl$sex_ratio)
+  n  <- dl$nages[2]
+  dl$sex_ratio[2, ac[(n - 2):n]] <- NA          # last three of species 2's bins
+
+  err <- check_err(dl)
+  expect_match(err, "sex_ratio is missing values for species 2")
+  expect_match(err, paste0("ages ", n - 2, "-", n))
+  expect_match(err, "SSB or SPR0 NA")
+})
+
+
+test_that("a maturity gap is named the same way", {
+  dl <- goa()
+  ac <- age_cols(dl$maturity)
+  dl$maturity[1, ac[2]] <- NA
+
+  err <- check_err(dl)
+  expect_match(err, "maturity is missing values for species 1, age 2 of")
+})
+
+
+test_that("scattered gaps are listed, not reported as a span", {
+  # range() would print ages 2 and 5 as "2-5" and implicate 3 and 4.
+  dl <- goa()
+  ac <- age_cols(dl$sex_ratio)
+  dl$sex_ratio[1, ac[c(2, 5)]] <- NA
+
+  expect_match(check_err(dl), "ages 2, 5 of")
+})
+
+
+test_that("rows are read by position, and a disagreeing Species column is reported", {
+  # rearrange_data() drops Species and hands the template a row-indexed matrix,
+  # so row i IS species i. Following the column instead would check the wrong
+  # species' nages.
+  dl <- goa()
+  dl$sex_ratio$Species <- rev(dl$sex_ratio$Species)
+
+  expect_match(check_err(dl), "sex_ratio\\$Species must match the row order")
+})
+
+
+test_that("a species with no row at all is reported", {
+  dl <- goa()
+  dl$maturity <- dl$maturity[-nrow(dl$maturity), , drop = FALSE]
+
+  err <- check_err(dl)
+  expect_match(err, "maturity has .* row\\(s\\) for .* species")
+  expect_match(err, "read past the end of the table")
+})
+
+
+test_that("an NA in nages does not abort the whole check", {
+  # `if(length(agec) < NA)` is "missing value where TRUE/FALSE needed", which
+  # would discard every error accumulated so far -- including nages' own.
+  dl <- goa()
+  dl$nages[2] <- NA
+
+  err <- check_err(dl)
+  expect_gt(length(err), 0)
+  expect_false(grepl("missing value where TRUE/FALSE needed", paste(err, collapse = " ")))
+})
+
+
+test_that("the check lives in data_check(), not only in this file", {
+  # test-mse-cap-and-hcr2-threshold.R keeps a transcription of the rule it
+  # tests; that is workable for arithmetic, but a validation rule tested only
+  # against a copy can be deleted from the package with the suite still green.
+  # This asserts the shipped function carries it.
+  src <- paste(deparse(body(data_check)), collapse = " ")
+  expect_match(src, "is missing values for species")
+  expect_match(src, "must match the row order")
 })

--- a/vignettes/data-without-excel.Rmd
+++ b/vignettes/data-without-excel.Rmd
@@ -444,7 +444,9 @@ simData$sex_ratio <- cbind(data.frame(Species = 1:nspp), sex_matrix)
 
 Where species carry different numbers of age bins, `maturity` and `sex_ratio` are as wide as the longest-lived species, and **each row must be filled across its own species' `nages`**. Columns past that are padding and may be `NA`.
 
-Getting this wrong is quiet. Spawner-per-recruit sums over every age of a species and scales by the proportion female, so one gap inside a species' own range leaves `SPR0` — and every SPR-based reference point built on it — `NA`. Nothing else reads these tables that way, so the model fits normally until a harvest control rule asks for reference points. `data_check()` names the species and the missing ages.
+Getting this wrong is quiet. Both tables are summed over age: spawning biomass uses `maturity` (times `sex_ratio` where a species is modelled one-sex), and spawner-per-recruit sums the same schedule. So a `maturity` gap leaves SSB `NA` for any species, and a `sex_ratio` gap does the same for a one-sex species. On a **two-sex** species `sex_ratio` reaches only spawner-per-recruit — so the model fits normally and the failure waits until a harvest control rule asks for reference points. `data_check()` names the table, the species and the missing ages.
+
+Rows are read by position: the `Species` column is dropped before the model sees these tables, so row *i* must be species *i*.
 
 ### Fixed selectivity (optional)
 

--- a/vignettes/data-without-excel.Rmd
+++ b/vignettes/data-without-excel.Rmd
@@ -442,6 +442,10 @@ colnames(sex_matrix) <- paste0("Age", 1:nages)
 simData$sex_ratio <- cbind(data.frame(Species = 1:nspp), sex_matrix)
 ```
 
+Where species carry different numbers of age bins, `maturity` and `sex_ratio` are as wide as the longest-lived species, and **each row must be filled across its own species' `nages`**. Columns past that are padding and may be `NA`.
+
+Getting this wrong is quiet. Spawner-per-recruit sums over every age of a species and scales by the proportion female, so one gap inside a species' own range leaves `SPR0` — and every SPR-based reference point built on it — `NA`. Nothing else reads these tables that way, so the model fits normally until a harvest control rule asks for reference points. `data_check()` names the species and the missing ages.
+
 ### Fixed selectivity (optional)
 
 Pre-specified selectivity-at-age values for fleets whose selectivity is fixed (not estimated). **Required** when any fleet has `Selectivity = "Fixed"`. Skip if all fleets estimate their own selectivity (as in this example).


### PR DESCRIPTION
`data_check()` now checks `maturity` and `sex_ratio` age coverage **per species**, not only against the widest one.

## The gap

```r
if(ncol(data_list$maturity)  <= max(data_list$nages)) ...
if(ncol(data_list$sex_ratio) <= max(data_list$nages)) ...
```

Both ask whether the table is wide enough for the **longest-lived** species. A table can be wide enough and still leave a shorter-column species short of its *own* bins — and the `[0, 1]` range check below reads over the gap with `na.rm`.

## Why it matters

`spawning_biomass_per_recruit()` (`src/TMB/spr.hpp`) sums across every age of a species and scales by the proportion female:

```cpp
spr += n(age) * weight(age) * maturity(age) * sex_ratio(age) * exp(-Z(age) * spawn_month / 12.0);
```

One gap inside a species' own age range makes `SPR0` `NA`, and with it `SPRtarget`, `SPRlimit`, and every SPR-based reference point.

Nothing else reads those tables the same way — the hindcast uses the sex ratio it estimates — so **the model fits normally until a harvest control rule asks for reference points**, and then `nlminb` reports `NA/NaN gradient evaluation`, naming neither the table nor the species.

## How it was found

The GOA multispecies workbook had the arrowtooth `sex_ratio` for ages 11–21 pasted 20 columns right of its `Age11..Age21` home, leaving those columns empty against 21 age bins. `read_data()` reads the sheet verbatim, so the saved fits carried the hole too.

Diagnosis, in order: the hindcast converged cleanly (obj 17854.7162, max gradient 1.7e-11, zero non-finite gradients across 699 parameters), so the model was healthy. Adding the HCR broke it, but not via `Plimit` — scalar `0.2`, the vector `c(0.2, 0, 0.2)` and `build_hcr()` defaults all failed identically, and phasing made no difference. Building at `estimateMode = 3` showed `SPR0`, `SPRtarget` and `SPRlimit` each carrying exactly **one non-finite value of three**, which localised it to one species, then to `sex_ratio`.

That same data now reports:

```
sex_ratio is missing values for species 2, ages 11-21; that species has 21
age bins. Spawner-per-recruit sums over every age, so a gap leaves SPR0 and
the reference points NA.
```

With the data corrected, the previously failing fit converges — obj 17854.7162, max gradient 3.05e-4, arrowtooth `SPR0` 0.8707 instead of `NA`, and sensible Tier 3 reference points (F40% 0.263 / 0.125 / 0.448).

## Not a false positive on ragged data

Ages past a species' own `nages` are padding and are **not** checked — that is the normal shape of every multispecies workbook, where pollock and cod carry 10 bins in a 21-column table. `test-data-check-age-coverage.R` asserts padding stays legal, and that the four bundled datasets pass.

## What I did NOT change

`per_recruit_survivors()`'s docstring says its unchecked preconditions (`Z.size() >= 2`, plus-group `Z` above zero) are ones "no age-structured species reaches". I initially thought this was a counter-example; it is not. Arrowtooth's plus-group `Z` was 0.20, comfortably above zero — the precondition held and the `NA` came from `sex_ratio`. `spr.hpp` is untouched.

## Verification

- `test-data-check-age-coverage.R` — 14 assertions: padding legal, a gap inside a species' range caught for both tables, singular/plural age wording, the column-count case left to the check that owns it, all bundled datasets clean.
- The real pre-fix GOA data now produces the named error rather than a `NaN` gradient.
- **Full suite clean**, 3 skips.
- No `man/` or `NAMESPACE` churn — `data_check()` is internal.
- `vignette("data-without-excel")` states the rule where a reader builds these tables by hand.
