### PR TITLE
docs: say what minfraction is, not just its default

### DIFF
--- a/R/7-plot_profile.R
+++ b/R/7-plot_profile.R
@@ -216,7 +216,10 @@
 #'   [profile.Rceattle()], or a list of them to compare models in facets (e.g.
 #'   the same profile run on two model configurations).
 #' @param weighted,relative,minfraction Passed to [profile_components()].
-#'   `minfraction` defaults to `0.01` here, as in `r4ss::SSplotProfile()`.
+#'   `minfraction` drops a component moving less than that fraction of the
+#'   TOTAL's change over the grid -- not an absolute number of objective units.
+#'   It defaults to `0.01` here, as in `r4ss::SSplotProfile()`, so a total
+#'   moving 60 units cuts at 0.6.
 #' @param add_cutoff Draw a horizontal line at `cutoff`. Off by default: the
 #'   cutoff is a statement about the total, and drawing it across the
 #'   components invites reading it as one about them.

--- a/man/plot_profile.Rd
+++ b/man/plot_profile.Rd
@@ -30,7 +30,10 @@ the same profile run on two model configurations).}
 \item{model_names}{Legend labels for the models.}
 
 \item{weighted, relative, minfraction}{Passed to \code{\link[=profile_components]{profile_components()}}.
-\code{minfraction} defaults to \code{0.01} here, as in \code{r4ss::SSplotProfile()}.}
+\code{minfraction} drops a component moving less than that fraction of the
+TOTAL's change over the grid -- not an absolute number of objective units.
+It defaults to \code{0.01} here, as in \code{r4ss::SSplotProfile()}, so a total
+moving 60 units cuts at 0.6.}
 
 \item{add_cutoff}{Draw a horizontal line at \code{cutoff}. Off by default: the
 cutoff is a statement about the total, and drawing it across the


### PR DESCRIPTION
Cole asked what `minfraction` actually is — "max delta for a component is <0.01?"

`plot_profile()`'s `@param` gave the default and the `r4ss::SSplotProfile()`
reference but never the definition, so `0.01` reads as an absolute number of
objective units. It is a fraction of the **total's** change over the grid:

```r
span <- diff(range(value))                       # per series, in NLL units
drop <- span < minfraction * span[["Total"]]
```

So a total moving 60 units cuts at 0.6; a total moving 2 cuts at 0.02. Same rule
as r4ss, which keeps a component when `column.max / column.max[1] >= minfraction`.

`profile_components()`'s own `@param` was already correct — this only fixes the
terser one that gets read first.